### PR TITLE
Bump service worker cache version to v16

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 // Guardians of Lajen Compendium — Service Worker v15
-const CACHE_NAME = 'gol-compendium-v15';
+const CACHE_NAME = 'gol-compendium-v16';
 const PRECACHE_URLS = ['/', '/index.html', '/icon-192.png', '/icon-512.png'];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
### Motivation
- Invalidate the previous service worker cache so clients receive refreshed assets by bumping the cache version from `gol-compendium-v15` to `gol-compendium-v16`.

### Description
- Update `public/sw.js` to set `const CACHE_NAME = 'gol-compendium-v16'` and make no other code changes.

### Testing
- Ran `npm run build` which completed successfully (Vite build finished; only non-blocking bundle warnings were reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d5666da8832eb96b341edc119d78)