### PR TITLE
Remove unreachable session_log import block in IOBar

### DIFF
--- a/src/components/common/IOBar.jsx
+++ b/src/components/common/IOBar.jsx
@@ -139,20 +139,6 @@ export default function IOBar({ db, backup, onImport }) {
           added += Math.max(0, newLen - exLen)
         })
 
-        // session_log goes to its own Supabase table, matched by session_number
-        if (incoming.session_log && Array.isArray(incoming.session_log)) {
-          for (const session of incoming.session_log) {
-            if (!session.id) continue
-            if (hasSupabase) {
-              // Upsert by session_number if it exists, otherwise by id
-              await supabase.from('session_log').upsert(session, {
-                onConflict: session.session_number != null ? 'session_number' : 'id'
-              })
-            }
-            added++
-          }
-        }
-
         // Write merged data back via upsert for each category
         const upsertPromises = []
         Object.keys(merged).forEach(k => {


### PR DESCRIPTION
### Motivation
- Remove dead code in `handleImport` that attempted to re-process `incoming.session_log` after it had already been handled and deleted, eliminating unreachable logic.

### Description
- Deleted the unreachable `if (incoming.session_log && Array.isArray(incoming.session_log)) { ... }` block in `src/components/common/IOBar.jsx` inside `handleImport`, leaving the earlier session_log processing and `delete incoming.session_log` intact and changing nothing else in the file.

### Testing
- Ran `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5665a3530832e91994b95c19a8c07)