### PR TITLE
Fix A+/A- scaling for tab inline text and decouple card-size font behavior

### DIFF
--- a/src/tabs/FamilyTree.jsx
+++ b/src/tabs/FamilyTree.jsx
@@ -308,9 +308,9 @@ function TreeNode({ node, selected, editMode, allNodeColors, onClick, onEdit, on
       onTouchStart={editMode ? onTouchStart : undefined}
     >
       {node.image && <img src={node.image} alt="" style={{ width: 44, height: 44, borderRadius: '50%', objectFit: 'cover', float: 'right', marginLeft: 6, marginBottom: 3, border: `2px solid ${col}` }} />}
-      <div style={{ fontSize: 11, fontWeight: 700, fontFamily: "'Cinzel', serif", color: col, lineHeight: 1.3, marginBottom: 1 }}>{node.name}</div>
-      {node.birth_year && <div style={{ fontSize: 9, color: 'var(--dim)' }}>{node.birth_year}{node.death_year ? ` \u2013 ${node.death_year}` : ''}</div>}
-      {node.title && <div style={{ fontSize: 9, color: 'var(--mut)', fontStyle: 'italic' }}>{node.title}</div>}
+      <div style={{ fontSize: '0.85em', fontWeight: 700, fontFamily: "'Cinzel', serif", color: col, lineHeight: 1.3, marginBottom: 1 }}>{node.name}</div>
+      {node.birth_year && <div style={{ fontSize: '0.69em', color: 'var(--dim)' }}>{node.birth_year}{node.death_year ? ` \u2013 ${node.death_year}` : ''}</div>}
+      {node.title && <div style={{ fontSize: '0.69em', color: 'var(--mut)', fontStyle: 'italic' }}>{node.title}</div>}
       {selected && editMode && (
         <div style={{ display: 'flex', gap: 3, marginTop: 5, flexWrap: 'wrap' }}>
           <button style={bs(col)} onClick={e => { e.stopPropagation(); onEdit(node) }}>✎ Edit</button>
@@ -321,7 +321,7 @@ function TreeNode({ node, selected, editMode, allNodeColors, onClick, onEdit, on
     </div>
   )
 }
-const bs = col => ({ background: 'none', border: `1px solid ${col}44`, color: col, fontSize: 9, cursor: 'pointer', padding: '1px 5px', borderRadius: 3 })
+const bs = col => ({ background: 'none', border: `1px solid ${col}44`, color: col, fontSize: '0.69em', cursor: 'pointer', padding: '1px 5px', borderRadius: 3 })
 
 // ── Main component ──────────────────────────────────────────────
 
@@ -531,12 +531,12 @@ function RelationshipWeb({ nodes, edges, allEdgeColors, allNodeColors, editMode,
         {/* Zoom controls */}
         <div style={{ position: 'absolute', bottom: 10, right: 10, display: 'flex', gap: 4, alignItems:'center', background:'rgba(0,0,0,.5)', borderRadius:8, padding:'4px 8px' }}>
           <button onClick={() => setZoom(z => Math.max(0.1, z - 0.15))}
-            style={{ width:28, height:28, borderRadius:6, background:'rgba(255,255,255,.1)', border:'1px solid var(--brd)', color:'var(--tx)', cursor:'pointer', fontSize:16 }}>−</button>
-          <span style={{ fontSize:10, color:'var(--cca)', minWidth:40, textAlign:'center', fontWeight:700 }}>{Math.round(zoom*100)}%</span>
+            style={{ width:28, height:28, borderRadius:6, background:'rgba(255,255,255,.1)', border:'1px solid var(--brd)', color:'var(--tx)', cursor:'pointer', fontSize: '1.23em' }}>−</button>
+          <span style={{ fontSize: '0.77em', color:'var(--cca)', minWidth:40, textAlign:'center', fontWeight:700 }}>{Math.round(zoom*100)}%</span>
           <button onClick={() => setZoom(z => Math.min(4, z + 0.15))}
-            style={{ width:28, height:28, borderRadius:6, background:'rgba(255,255,255,.1)', border:'1px solid var(--brd)', color:'var(--tx)', cursor:'pointer', fontSize:16 }}>+</button>
+            style={{ width:28, height:28, borderRadius:6, background:'rgba(255,255,255,.1)', border:'1px solid var(--brd)', color:'var(--tx)', cursor:'pointer', fontSize: '1.23em' }}>+</button>
           <button onClick={() => { setZoom(1); setPan({x:0,y:0}) }}
-            style={{ width:28, height:28, borderRadius:6, background:'rgba(255,255,255,.1)', border:'1px solid var(--brd)', color:'var(--mut)', cursor:'pointer', fontSize:12 }}>⊙</button>
+            style={{ width:28, height:28, borderRadius:6, background:'rgba(255,255,255,.1)', border:'1px solid var(--brd)', color:'var(--mut)', cursor:'pointer', fontSize: '0.92em' }}>⊙</button>
         </div>
       </div>
 
@@ -545,20 +545,20 @@ function RelationshipWeb({ nodes, edges, allEdgeColors, allNodeColors, editMode,
         <div style={{ marginTop: 8, padding: '10px 14px', background: 'var(--card)',
           border: '1px solid var(--brd)', borderRadius: 8 }}>
           <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center', marginBottom:6 }}>
-            <div style={{ fontFamily:"'Cinzel',serif", fontSize:13, color: allNodeColors[sel.node_type]||'var(--cc)' }}>
+            <div style={{ fontFamily:"'Cinzel',serif", fontSize: '1em', color: allNodeColors[sel.node_type]||'var(--cc)' }}>
               {sel.name}
             </div>
             <button onClick={() => setSelected(null)}
-              style={{ background:'none', border:'none', color:'var(--mut)', cursor:'pointer', fontSize:16 }}>✕</button>
+              style={{ background:'none', border:'none', color:'var(--mut)', cursor:'pointer', fontSize: '1.23em' }}>✕</button>
           </div>
-          {sel.title && <div style={{ fontSize:10, color:'var(--mut)', marginBottom:6 }}>{sel.title}</div>}
+          {sel.title && <div style={{ fontSize: '0.77em', color:'var(--mut)', marginBottom:6 }}>{sel.title}</div>}
           {selEdges.length > 0 && (
             <div style={{ display:'flex', flexWrap:'wrap', gap:4 }}>
               {selEdges.map((e, i) => {
                 const other = nodes.find(n => n.id === (e.from === sel.id ? e.to : e.from))
                 const c = allEdgeColors[e.type] || '#666688'
                 return (
-                  <span key={i} style={{ fontSize:10, padding:'2px 8px', borderRadius:10,
+                  <span key={i} style={{ fontSize: '0.77em', padding:'2px 8px', borderRadius:10,
                     background:`${c}22`, color:c, border:`1px solid ${c}44` }}>
                     {e.type}: {other?.name || '?'}
                   </span>
@@ -568,9 +568,9 @@ function RelationshipWeb({ nodes, edges, allEdgeColors, allNodeColors, editMode,
           )}
           {editMode && (
             <div style={{ display:'flex', gap:6, marginTop:8 }}>
-              <button className="btn btn-sm btn-outline" style={{ fontSize:10 }}
+              <button className="btn btn-sm btn-outline" style={{ fontSize: '0.77em' }}
                 onClick={() => setNodeModal(sel)}>✎ Edit</button>
-              <button className="btn btn-sm btn-outline" style={{ fontSize:10, color:'var(--cl)', borderColor:'var(--cl)' }}
+              <button className="btn btn-sm btn-outline" style={{ fontSize: '0.77em', color:'var(--cl)', borderColor:'var(--cl)' }}
                 onClick={() => setEdgeModal({ from: sel.id })}>+ Add Relation</button>
             </div>
           )}
@@ -765,11 +765,11 @@ export default function FamilyTree({ db }) {
     <div>
       {/* ── Toolbar ── */}
       <div className="tbar" style={{ flexWrap: 'wrap', gap: 6 }}>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: 14, color: 'var(--cl)' }}>🌳 Family Tree</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.08em', color: 'var(--cl)' }}>🌳 Family Tree</div>
         <div style={{ display:'flex', gap:3 }}>
           {[['🌳 Tree','tree'],['🕸 Web','web']].map(([l,v]) => (
             <button key={v} onClick={() => setViewMode(v)}
-              style={{ fontSize:10, padding:'3px 10px', borderRadius:10,
+              style={{ fontSize: '0.77em', padding:'3px 10px', borderRadius:10,
                 background: viewMode===v ? 'var(--cl)' : 'none',
                 color: viewMode===v ? '#000' : 'var(--dim)',
                 border: `1px solid ${viewMode===v ? 'var(--cl)' : 'var(--brd)'}`,
@@ -793,7 +793,7 @@ export default function FamilyTree({ db }) {
         )}
         <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginLeft: 'auto' }}>
           <button style={bs('var(--dim)')} onClick={() => setZoom(z => Math.max(0.25, z - 0.15))}>−</button>
-          <span style={{ fontSize: 9, color: 'var(--cca)', minWidth: 32, textAlign: 'center' }}>{Math.round(zoom*100)}%</span>
+          <span style={{ fontSize: '0.69em', color: 'var(--cca)', minWidth: 32, textAlign: 'center' }}>{Math.round(zoom*100)}%</span>
           <button style={bs('var(--dim)')} onClick={() => setZoom(z => Math.min(3, z + 0.15))}>+</button>
           <button style={bs('var(--mut)')} onClick={() => { setZoom(1); setPan({ x:0, y:0 }) }} title="Reset view">⊙</button>
         </div>
@@ -803,26 +803,26 @@ export default function FamilyTree({ db }) {
       {/* ── BG controls ── */}
       {editMode && (
         <div className="tbar" style={{ paddingTop: 0, gap: 10, flexWrap: 'wrap' }}>
-          <span style={{ fontSize: 10, color: 'var(--dim)', display: 'flex', alignItems: 'center', gap: 5 }}>
+          <span style={{ fontSize: '0.77em', color: 'var(--dim)', display: 'flex', alignItems: 'center', gap: 5 }}>
             BG: <input type="color" value={bgColor} onChange={e => { setBgColor(e.target.value); persist(null,null,e.target.value,undefined) }} style={{ width:26, height:20, padding:0, border:'1px solid var(--brd)', borderRadius:3, cursor:'pointer' }} />
           </span>
-          <label style={{ fontSize:10, color:'var(--dim)', cursor:'pointer', display:'flex', alignItems:'center', gap:4 }}>
+          <label style={{ fontSize: '0.77em', color:'var(--dim)', cursor:'pointer', display:'flex', alignItems:'center', gap:4 }}>
             🖼 BG: <input ref={bgRef} type="file" accept="image/*" style={{ display:'none' }} onChange={e => { const f=e.target.files[0];if(!f)return;const r=new FileReader();r.onload=ev=>{setBgImage(ev.target.result);persist(null,null,null,ev.target.result)};r.readAsDataURL(f) }} />
             <span style={{ color:'var(--cc)', textDecoration:'underline' }}>Upload</span>
           </label>
-          {bgImage && <button className="btn btn-sm btn-outline" style={{ color:'#ff3355', borderColor:'#ff335544', fontSize:9 }} onClick={() => { setBgImage(null); persist(null,null,null,null) }}>Remove BG</button>}
-          <span style={{ fontSize:9, color:'var(--mut)' }}>Drag nodes to reposition · Scroll to zoom · Drag background to pan</span>
+          {bgImage && <button className="btn btn-sm btn-outline" style={{ color:'#ff3355', borderColor:'#ff335544', fontSize: '0.69em' }} onClick={() => { setBgImage(null); persist(null,null,null,null) }}>Remove BG</button>}
+          <span style={{ fontSize: '0.69em', color:'var(--mut)' }}>Drag nodes to reposition · Scroll to zoom · Drag background to pan</span>
         </div>
       )}
 
       {/* ── Unknown panel ── */}
       {showUnk && unknownEdges.length > 0 && (
         <div style={{ margin:'4px 0', padding:10, background:`${UNK_COL}11`, border:`1px solid ${UNK_COL}44`, borderRadius:6 }}>
-          <div style={{ fontSize:10, color:UNK_COL, fontWeight:700, marginBottom:6 }}>⚠ Unknown Relationships — click any to edit:</div>
+          <div style={{ fontSize: '0.77em', color:UNK_COL, fontWeight:700, marginBottom:6 }}>⚠ Unknown Relationships — click any to edit:</div>
           <div style={{ display:'flex', flexWrap:'wrap', gap:5 }}>
             {unknownEdges.map(e => {
               const fn = nodes.find(n => n.id===e.from), tn = nodes.find(n => n.id===e.to)
-              return <button key={e.id} style={{ fontSize:9, padding:'2px 7px', borderRadius:4, background:'var(--card)', border:`1px solid ${UNK_COL}66`, color:UNK_COL, cursor:'pointer' }} onClick={() => { setEdgeModal(e); setShowUnk(false) }}>{fn?.name||'?'} ↔ {tn?.name||'?'}</button>
+              return <button key={e.id} style={{ fontSize: '0.69em', padding:'2px 7px', borderRadius:4, background:'var(--card)', border:`1px solid ${UNK_COL}66`, color:UNK_COL, cursor:'pointer' }} onClick={() => { setEdgeModal(e); setShowUnk(false) }}>{fn?.name||'?'} ↔ {tn?.name||'?'}</button>
             })}
           </div>
         </div>
@@ -833,7 +833,7 @@ export default function FamilyTree({ db }) {
         <div className="empty">
           <div className="empty-icon">🌳</div>
           <p>No family tree yet.</p>
-          <p style={{ fontSize:11, color:'var(--mut)', maxWidth:340, margin:'6px auto 14px' }}>
+          <p style={{ fontSize: '0.85em', color:'var(--mut)', maxWidth:340, margin:'6px auto 14px' }}>
             Click <strong>⟳ Sync Characters</strong> to auto-populate, or add people manually in Edit Mode.
           </p>
           <div style={{ display:'flex', gap:10, justifyContent:'center', flexWrap:'wrap' }}>
@@ -860,7 +860,7 @@ export default function FamilyTree({ db }) {
           {syncToast && (
             <div style={{ position:'absolute', top:10, left:'50%', transform:'translateX(-50%)', zIndex:50,
               background:'rgba(0,0,0,.85)', border:'1px solid var(--sl)', borderRadius:6,
-              padding:'5px 14px', fontSize:11, color:'var(--sl)', whiteSpace:'nowrap', pointerEvents:'none' }}>
+              padding:'5px 14px', fontSize: '0.85em', color:'var(--sl)', whiteSpace:'nowrap', pointerEvents:'none' }}>
               {syncToast}
             </div>
           )}
@@ -905,7 +905,7 @@ export default function FamilyTree({ db }) {
 
       {/* ── Legend ── */}
       {nodes.length > 0 && (
-        <div style={{ display:'flex', gap:8, flexWrap:'wrap', padding:'6px 0', fontSize:9, color:'var(--dim)' }}>
+        <div style={{ display:'flex', gap:8, flexWrap:'wrap', padding:'6px 0', fontSize: '0.69em', color:'var(--dim)' }}>
           {allEdgeTypes.map(t => {
             const c = allEdgeColors[t]||'#666688', isUnk = t==='Unknown', cnt = isUnk ? unknownEdges.length : 0
             return (
@@ -921,7 +921,7 @@ export default function FamilyTree({ db }) {
       )}
 
       {nodes.length > 0 && (
-        <div style={{ fontSize:9, color:'var(--mut)', paddingBottom:4 }}>
+        <div style={{ fontSize: '0.69em', color:'var(--mut)', paddingBottom:4 }}>
           {nodes.length} people · {edges.length} relationships
           {unknownEdges.length > 0 && <span style={{ color:UNK_COL, marginLeft:8, fontWeight:700 }}>· {unknownEdges.length} Unknown — click ⚠ to review</span>}
         </div>
@@ -940,7 +940,7 @@ export default function FamilyTree({ db }) {
           onAddEdgeType={(t,c) => saveCustom([...customEdgeTypes,t], undefined, {...customEdgeColors,[t]:c}, undefined)} />}
       </Modal>
       <Modal open={clearDlg} onClose={() => setClearDlg(false)} title="Clear Family Tree" color="#ff3355">
-        <p style={{ fontSize:12, color:'var(--dim)', marginBottom:16 }}>Remove all {nodes.length} people and {edges.length} relationships? Cannot be undone.</p>
+        <p style={{ fontSize: '0.92em', color:'var(--dim)', marginBottom:16 }}>Remove all {nodes.length} people and {edges.length} relationships? Cannot be undone.</p>
         <div className="modal-actions">
           <button className="btn btn-outline" onClick={() => setClearDlg(false)}>Cancel</button>
           <button className="btn btn-primary" style={{ background:'#ff3355' }} onClick={clearTree}>Clear Tree</button>
@@ -950,7 +950,7 @@ export default function FamilyTree({ db }) {
       <Modal open={!!deleteConfirm} onClose={() => setDeleteConfirm(null)} title="Delete Person" color="#ff3355">
         {deleteConfirm && (
           <>
-            <p style={{ fontSize:12, color:'var(--dim)', marginBottom:16 }}>
+            <p style={{ fontSize: '0.92em', color:'var(--dim)', marginBottom:16 }}>
               Remove <strong style={{ color:'var(--tx)' }}>{deleteConfirm.name}</strong> from the tree?
               All their relationships will also be removed. This cannot be undone.
             </p>
@@ -1010,11 +1010,11 @@ function NodeForm({ node, onSave, onCancel, db, nodeTypes, onAddNodeType }) {
       <div className="field"><label>Portrait Image</label>
         <div style={{display:'flex',gap:8,alignItems:'center'}}>
           {image && <img src={image} alt="" style={{width:40,height:40,borderRadius:'50%',objectFit:'cover',border:'1px solid var(--brd)'}} />}
-          <label style={{cursor:'pointer',fontSize:11,color:'var(--cc)',textDecoration:'underline'}}>
+          <label style={{cursor:'pointer',fontSize: '0.85em',color:'var(--cc)',textDecoration:'underline'}}>
             {image?'Change':'Upload photo'}
             <input type="file" accept="image/*" style={{display:'none'}} onChange={e=>{const f=e.target.files[0];if(!f)return;const r=new FileReader();r.onload=ev=>setImage(ev.target.result);r.readAsDataURL(f)}} />
           </label>
-          {image && <button style={{background:'none',border:'none',color:'#ff3355',cursor:'pointer',fontSize:11}} onClick={()=>setImage(null)}>Remove</button>}
+          {image && <button style={{background:'none',border:'none',color:'#ff3355',cursor:'pointer',fontSize: '0.85em'}} onClick={()=>setImage(null)}>Remove</button>}
         </div>
       </div>
       <div className="field"><label>Notes</label><textarea value={form.notes} onChange={s('notes')} /></div>
@@ -1064,15 +1064,15 @@ function EdgeForm({ edge, nodes, onSave, onDelete, onCancel, edgeTypes, edgeColo
         {form.type==='__custom__' && (
           <div style={{display:'flex',gap:8,marginTop:4,alignItems:'center'}}>
             <input style={{flex:1}} value={customType} onChange={e=>setCustomType(e.target.value)} placeholder="e.g. Ix'Citlatl Member, The Rebels" />
-            <span style={{fontSize:9,color:'var(--dim)'}}>Color:</span>
+            <span style={{fontSize: '0.69em',color:'var(--dim)'}}>Color:</span>
             <input type="color" value={customColor} onChange={e=>setCustomColor(e.target.value)} style={{width:28,height:22,padding:0,border:'1px solid var(--brd)',borderRadius:3,cursor:'pointer'}} />
           </div>
         )}
-        {dirNote && <div style={{fontSize:9,color:'var(--cca)',marginTop:3}}>{dirNote}</div>}
+        {dirNote && <div style={{fontSize: '0.69em',color:'var(--cca)',marginTop:3}}>{dirNote}</div>}
       </div>
       <div style={{display:'flex',alignItems:'center',gap:6,marginBottom:8}}>
         <div style={{width:24,height:3,background:previewCol,borderRadius:2}} />
-        <span style={{fontSize:9,color:previewCol}}>{form.type!=='__custom__'?form.type:customType||'Custom'}</span>
+        <span style={{fontSize: '0.69em',color:previewCol}}>{form.type!=='__custom__'?form.type:customType||'Custom'}</span>
       </div>
       <div className="field">
         <label>Custom Label <span style={{color:'var(--mut)',fontWeight:400}}>(optional — overrides type name on the line)</span></label>

--- a/src/tabs/Flags.jsx
+++ b/src/tabs/Flags.jsx
@@ -50,11 +50,11 @@ export default function Flags({ db }) {
   return (
     <div>
       <div className="tbar">
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: 15, color: 'var(--cfl)' }}>🚩 Flags & Review</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.15em', color: 'var(--cfl)' }}>🚩 Flags & Review</div>
         <div style={{ display:'flex', gap:3 }}>
           {[['XS',8],['S',5],['M',3],['L',2],['XL',1]].map(([l,n]) => (
             <button key={l} onClick={() => saveColCount(n)}
-              style={{ fontSize:9, padding:'2px 7px', borderRadius:8,
+              style={{ fontSize: '0.69em', padding:'2px 7px', borderRadius:8,
                 background: colCount===n ? 'var(--cfl)' : 'none',
                 color: colCount===n ? '#000' : 'var(--dim)',
                 border: `1px solid ${colCount===n ? 'var(--cfl)' : 'var(--brd)'}`,
@@ -62,7 +62,7 @@ export default function Flags({ db }) {
           ))}
         
         <button onClick={toggleDividers}
-          style={{ fontSize:9, padding:'2px 7px', borderRadius:8, marginLeft:8,
+          style={{ fontSize: '0.69em', padding:'2px 7px', borderRadius:8, marginLeft:8,
             background: dividers ? 'rgba(255,255,255,.08)' : 'none',
             color: dividers ? 'var(--tx)' : 'var(--mut)',
             border:'1px solid var(--brd)', cursor:'pointer' }}>
@@ -79,7 +79,7 @@ export default function Flags({ db }) {
             <button key={k} className={`fp ${filter===k?'active':''}`} style={{ color: 'var(--cfl)' }} onClick={() => setFilter(k)}>{l}</button>
           ))}
         </div>
-        <span style={{ fontSize: 10, color: 'var(--mut)', marginLeft: 8 }}>
+        <span style={{ fontSize: '0.77em', color: 'var(--mut)', marginLeft: 8 }}>
           {flags.filter(f => !f.resolved).length} active · {flags.filter(f => f.resolved).length} resolved
         </span>
       </div>
@@ -97,16 +97,16 @@ export default function Flags({ db }) {
         return (
           <div key={f.id} className="flag-card" style={{ opacity: f.resolved ? 0.6 : 1, breakInside: 'avoid', marginBottom: 6 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <div style={{ fontSize: 12, fontWeight: 600, color: f.resolved ? 'var(--dim)' : 'var(--tx)', textDecoration: f.resolved ? 'line-through' : 'none' }}>
+              <div style={{ fontSize: '0.92em', fontWeight: 600, color: f.resolved ? 'var(--dim)' : 'var(--tx)', textDecoration: f.resolved ? 'line-through' : 'none' }}>
                 {f.name}
               </div>
               <span className="flag-pri" style={{ background: `${pc}22`, color: pc, border: `1px solid ${pc}44` }}>
                 {f.priority || 'none'}
               </span>
             </div>
-            {f.detail && <div style={{ fontSize: 11, color: 'var(--dim)', marginTop: 3 }}>{f.detail}</div>}
+            {f.detail && <div style={{ fontSize: '0.85em', color: 'var(--dim)', marginTop: 3 }}>{f.detail}</div>}
             {f.resolved && f.resolved_at && (
-              <div style={{ fontSize: 9, color: 'var(--mut)', marginTop: 3 }}>Resolved {new Date(f.resolved_at).toLocaleDateString()}</div>
+              <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 3 }}>Resolved {new Date(f.resolved_at).toLocaleDateString()}</div>
             )}
             <div className="entry-actions" style={{ marginTop: 4 }}>
               {!f.resolved

--- a/src/tabs/Inventory.jsx
+++ b/src/tabs/Inventory.jsx
@@ -63,7 +63,7 @@ function ColorPicker({ value, onChange, onClose }) {
       background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 10,
       padding: 10, width: 170, boxShadow: '0 4px 20px rgba(0,0,0,.6)' }}
       onClick={e => e.stopPropagation()}>
-      <div style={{ fontSize: 9, color: 'var(--mut)', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '.05em' }}>Colour</div>
+      <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '.05em' }}>Colour</div>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5,1fr)', gap: 4, marginBottom: 8 }}>
         {PRESET_COLORS.map(c => (
           <button key={c} onClick={() => { onChange(c); onClose() }}
@@ -75,7 +75,7 @@ function ColorPicker({ value, onChange, onClose }) {
       <input type="color" value={value || '#1a4a6b'} onChange={e => onChange(e.target.value)}
         style={{ width: '100%', height: 28, border: 'none', borderRadius: 6, cursor: 'pointer', background: 'none' }} />
       <button onClick={onClose}
-        style={{ marginTop: 6, width: '100%', fontSize: 10, padding: '3px 0',
+        style={{ marginTop: 6, width: '100%', fontSize: '0.77em', padding: '3px 0',
           background: 'none', border: '1px solid var(--brd)', borderRadius: 6,
           color: 'var(--mut)', cursor: 'pointer' }}>Done</button>
     </div>
@@ -100,19 +100,19 @@ function EntryTile({ entry, bubbleColor, onOpen, search }) {
           onError={e => e.target.style.display = 'none'} />
       )}
       {(entry.transfers || []).length > 0 && (
-        <span style={{ position: 'absolute', top: 6, right: 6, fontSize: 9,
+        <span style={{ position: 'absolute', top: 6, right: 6, fontSize: '0.69em',
           background: 'rgba(255,170,51,.2)', color: 'var(--sp)',
           border: '1px solid rgba(255,170,51,.3)', borderRadius: 4, padding: '1px 4px' }}>↔</span>
       )}
-      <div style={{ fontSize: 11, fontWeight: 600, lineHeight: 1.3, color: 'var(--tx)', marginBottom: 2 }}
+      <div style={{ fontSize: '0.85em', fontWeight: 600, lineHeight: 1.3, color: 'var(--tx)', marginBottom: 2 }}
         dangerouslySetInnerHTML={{ __html: highlight(entry.name || '', search) }} />
       {cat && (
-        <div style={{ fontSize: 9, color: tileColor, textTransform: 'uppercase', letterSpacing: '.03em' }}>
+        <div style={{ fontSize: '0.69em', color: tileColor, textTransform: 'uppercase', letterSpacing: '.03em' }}>
           {cat.icon} {entry.category}
         </div>
       )}
       {entry.color_material && (
-        <div style={{ fontSize: 9, color: 'var(--mut)', marginTop: 2 }}>{entry.color_material}</div>
+        <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 2 }}>{entry.color_material}</div>
       )}
       {entry.status && (
         <div style={{ marginTop: 3 }}>
@@ -158,9 +158,9 @@ function CharBubble({ char, entries, idx, chars, search, onOpenEntry,
               border: `2px solid ${bubbleColor}` }}
             onError={e => e.target.style.display = 'none'} />
         )}
-        <div style={{ flex: 1, fontFamily: "'Cinzel',serif", fontSize: 12,
+        <div style={{ flex: 1, fontFamily: "'Cinzel',serif", fontSize: '0.92em',
           fontWeight: 700, color: bubbleColor }}>{name}</div>
-        <div style={{ fontSize: 10, color: 'var(--mut)' }}>
+        <div style={{ fontSize: '0.77em', color: 'var(--mut)' }}>
           {entries.length} item{entries.length !== 1 ? 's' : ''}
         </div>
         {/* Color dot */}
@@ -180,14 +180,14 @@ function CharBubble({ char, entries, idx, chars, search, onOpenEntry,
 
       {/* Entries grouped by category */}
       {entries.length === 0 ? (
-        <div style={{ fontSize: 10, color: 'var(--mut)', padding: '8px 0', textAlign: 'center' }}>No items</div>
+        <div style={{ fontSize: '0.77em', color: 'var(--mut)', padding: '8px 0', textAlign: 'center' }}>No items</div>
       ) : (
         catOrder.map(catId => {
           const cat = CAT_MAP[catId]
           const catEntries = byCategory[catId]
           return (
             <div key={catId} style={{ marginBottom: 10 }}>
-              <div style={{ fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
+              <div style={{ fontSize: '0.69em', fontWeight: 700, textTransform: 'uppercase',
                 letterSpacing: '.06em', color: cat?.color || 'var(--dim)',
                 marginBottom: 5 }}>
                 {cat?.icon} {catId}
@@ -231,11 +231,11 @@ function EntryPopup({ entry, allEntries, chars, db, onClose, onEdit, onTransfer,
 
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 14 }}>
           <div>
-            <div style={{ fontFamily: "'Cinzel',serif", fontSize: 15, color: tileColor }}>{entry.name}</div>
-            {cat && <div style={{ fontSize: 10, color: cat.color, marginTop: 2 }}>{cat.icon} {entry.category}</div>}
+            <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.15em', color: tileColor }}>{entry.name}</div>
+            {cat && <div style={{ fontSize: '0.77em', color: cat.color, marginTop: 2 }}>{cat.icon} {entry.category}</div>}
           </div>
           <button onClick={onClose} style={{ background: 'none', border: 'none',
-            cursor: 'pointer', fontSize: 18, color: 'var(--mut)', marginLeft: 10 }}>✕</button>
+            cursor: 'pointer', fontSize: '1.38em', color: 'var(--mut)', marginLeft: 10 }}>✕</button>
         </div>
 
         {/* Image */}
@@ -250,19 +250,19 @@ function EntryPopup({ entry, allEntries, chars, db, onClose, onEdit, onTransfer,
             <div style={{ width: '100%', height: 50, border: '1px dashed var(--brd)',
               borderRadius: 8, background: 'var(--card)', display: 'flex',
               alignItems: 'center', justifyContent: 'center',
-              color: 'var(--mut)', fontSize: 11 }}>No image</div>
+              color: 'var(--mut)', fontSize: '0.85em' }}>No image</div>
           )}
           <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
-            <label className="btn btn-sm btn-outline" style={{ cursor: 'pointer', fontSize: 10 }}>
+            <label className="btn btn-sm btn-outline" style={{ cursor: 'pointer', fontSize: '0.77em' }}>
               {uploadingImg === entry.id ? 'Uploading…' : '⬆ Upload'}
               <input type="file" accept="image/*" style={{ display: 'none' }}
                 onChange={e => { const f = e.target.files[0]; if (f) handleImageUpload(entry.id, f); e.target.value = '' }} />
             </label>
-            <button className="btn btn-sm btn-outline" style={{ fontSize: 10 }}
+            <button className="btn btn-sm btn-outline" style={{ fontSize: '0.77em' }}
               onClick={() => { onClose(); setPickerFor(entry.id) }}>🖼 Browse Library</button>
             {entry.image && (
               <button className="btn btn-sm btn-outline"
-                style={{ fontSize: 10, color: '#ff3355', borderColor: '#ff335544' }}
+                style={{ fontSize: '0.77em', color: '#ff3355', borderColor: '#ff335544' }}
                 onClick={() => {
                   const it = allEntries.find(x => x.id === entry.id)
                   if (it) db.upsertEntry('inventory', { ...it, image: null })
@@ -279,31 +279,31 @@ function EntryPopup({ entry, allEntries, chars, db, onClose, onEdit, onTransfer,
           ['Books', (entry.books || []).join(', ')],
         ].filter(([, v]) => v).map(([label, val]) => (
           <div key={label} style={{ marginBottom: 8 }}>
-            <div style={{ fontSize: 9, fontWeight: 700, color: tileColor,
+            <div style={{ fontSize: '0.69em', fontWeight: 700, color: tileColor,
               textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>{label}</div>
-            <div style={{ fontSize: 12, color: 'var(--tx)' }}>{val}</div>
+            <div style={{ fontSize: '0.92em', color: 'var(--tx)' }}>{val}</div>
           </div>
         ))}
 
         {entry.description && (
           <div style={{ marginBottom: 8 }}>
-            <div style={{ fontSize: 9, fontWeight: 700, color: tileColor, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Description</div>
-            <div style={{ fontSize: 12, color: 'var(--tx)', lineHeight: 1.6 }}>{entry.description}</div>
+            <div style={{ fontSize: '0.69em', fontWeight: 700, color: tileColor, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Description</div>
+            <div style={{ fontSize: '0.92em', color: 'var(--tx)', lineHeight: 1.6 }}>{entry.description}</div>
           </div>
         )}
         {entry.significance && (
           <div style={{ marginBottom: 8 }}>
-            <div style={{ fontSize: 9, fontWeight: 700, color: tileColor, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Significance</div>
-            <div style={{ fontSize: 12, color: 'var(--tx)', lineHeight: 1.6 }}>{entry.significance}</div>
+            <div style={{ fontSize: '0.69em', fontWeight: 700, color: tileColor, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Significance</div>
+            <div style={{ fontSize: '0.92em', color: 'var(--tx)', lineHeight: 1.6 }}>{entry.significance}</div>
           </div>
         )}
 
         {(entry.transfers || []).length > 0 && (
           <div style={{ marginTop: 10, paddingTop: 10, borderTop: '1px solid var(--brd)' }}>
-            <div style={{ fontSize: 9, fontWeight: 700, color: 'var(--sp)',
+            <div style={{ fontSize: '0.69em', fontWeight: 700, color: 'var(--sp)',
               textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 6 }}>↔ Transfer History</div>
             {entry.transfers.map((t, i) => (
-              <div key={i} style={{ fontSize: 11, color: 'var(--dim)', marginBottom: 3 }}>
+              <div key={i} style={{ fontSize: '0.85em', color: 'var(--dim)', marginBottom: 3 }}>
                 {t.from || '?'} → {t.to || '?'}
                 {t.note ? ` · ${t.note}` : ''}
                 {t.when ? <span style={{ color: 'var(--mut)' }}> ({t.when})</span> : ''}
@@ -314,7 +314,7 @@ function EntryPopup({ entry, allEntries, chars, db, onClose, onEdit, onTransfer,
 
         {entry.notes && (
           <div style={{ marginTop: 10, paddingTop: 10, borderTop: '1px solid var(--brd)',
-            fontSize: 11, color: 'var(--dim)', lineHeight: 1.6 }}>{entry.notes}</div>
+            fontSize: '0.85em', color: 'var(--dim)', lineHeight: 1.6 }}>{entry.notes}</div>
         )}
 
         <div style={{ display: 'flex', gap: 8, marginTop: 16, justifyContent: 'flex-end' }}>
@@ -507,7 +507,7 @@ export default function Inventory({ db }) {
 
         {/* Category filter */}
         <select value={filterCat} onChange={e => setFilterCat(e.target.value)}
-          style={{ fontSize: 10, padding: '4px 8px', background: 'var(--sf)',
+          style={{ fontSize: '0.77em', padding: '4px 8px', background: 'var(--sf)',
             border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
           <option value="all">All categories</option>
           {CATEGORIES.map(c => <option key={c.id} value={c.id}>{c.icon} {c.id}</option>)}
@@ -515,7 +515,7 @@ export default function Inventory({ db }) {
 
         {/* Character filter */}
         <select value={filterChar} onChange={e => { setFilterChar(e.target.value); setFilterChars(new Set()) }}
-          style={{ fontSize: 10, padding: '4px 8px', background: 'var(--sf)',
+          style={{ fontSize: '0.77em', padding: '4px 8px', background: 'var(--sf)',
             border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
           <option value="all">All characters</option>
           {usedChars.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
@@ -524,7 +524,7 @@ export default function Inventory({ db }) {
         {/* Group filter */}
         {allGroups.length > 0 && (
           <select value={filterGroup} onChange={e => setFilterGroup(e.target.value)}
-            style={{ fontSize: 10, padding: '4px 8px', background: 'var(--sf)',
+            style={{ fontSize: '0.77em', padding: '4px 8px', background: 'var(--sf)',
               border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
             <option value="all">All groups</option>
             {allGroups.map(g => <option key={g} value={g}>{g}</option>)}
@@ -546,7 +546,7 @@ export default function Inventory({ db }) {
         {/* List sort (only in list mode) */}
         {viewMode === 'list' && (
           <select value={sortBy} onChange={e => setSortBy(e.target.value)}
-            style={{ fontSize: 10, padding: '4px 8px', background: 'var(--sf)',
+            style={{ fontSize: '0.77em', padding: '4px 8px', background: 'var(--sf)',
               border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
             <option value="holder">Sort: By Holder</option>
             <option value="name">Sort: A → Z</option>
@@ -556,7 +556,7 @@ export default function Inventory({ db }) {
 
         {/* Column picker */}
         <div style={{ position: 'relative' }}>
-          <button className="btn btn-sm btn-outline" style={{ fontSize: 10 }}
+          <button className="btn btn-sm btn-outline" style={{ fontSize: '0.77em' }}
             onClick={() => setShowColPicker(p => !p)}
             title="Column count">⊞ {columns} col</button>
           {showColPicker && (
@@ -565,7 +565,7 @@ export default function Inventory({ db }) {
               padding: 10, display: 'flex', gap: 6 }}>
               {[1,2,3,4,5,8].map(n => (
                 <button key={n} onClick={() => { saveColumns(n); setShowColPicker(false) }}
-                  style={{ width: 30, height: 30, borderRadius: 6, fontSize: 12, fontWeight: 700,
+                  style={{ width: 30, height: 30, borderRadius: 6, fontSize: '0.92em', fontWeight: 700,
                     background: columns === n ? 'var(--ci)' : 'var(--card)',
                     color: columns === n ? '#000' : 'var(--tx)',
                     border: `1px solid ${columns === n ? 'var(--ci)' : 'var(--brd)'}`,
@@ -580,7 +580,7 @@ export default function Inventory({ db }) {
       </div>
 
       {/* ── Stats bar ── */}
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 10, fontSize: 10, color: 'var(--mut)' }}>
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 10, fontSize: '0.77em', color: 'var(--mut)' }}>
         <span>{filtered.length} of {allEntries.length} entries</span>
         {CATEGORIES.filter(c => filtered.some(e => (e.category || 'Other') === c.id)).map(c => (
           <span key={c.id} style={{ color: c.color }}>
@@ -641,7 +641,7 @@ export default function Inventory({ db }) {
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
                   <div className="entry-title"
                     dangerouslySetInnerHTML={{ __html: highlight(e.name || '', search) }} />
-                  <div style={{ fontSize: 9, color: tileColor, flexShrink: 0, marginLeft: 6 }}>
+                  <div style={{ fontSize: '0.69em', color: tileColor, flexShrink: 0, marginLeft: 6 }}>
                     {cat?.icon} {e.category}
                   </div>
                 </div>
@@ -655,7 +655,7 @@ export default function Inventory({ db }) {
                   {(e.books || []).map(b => <span key={b} className="badge badge-book">{b}</span>)}
                 </div>
                 {e.color_material && (
-                  <div style={{ fontSize: 10, color: 'var(--dim)', marginTop: 3 }}>{e.color_material}</div>
+                  <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginTop: 3 }}>{e.color_material}</div>
                 )}
               </div>
             )

--- a/src/tabs/Items.jsx
+++ b/src/tabs/Items.jsx
@@ -42,14 +42,14 @@ function ItemTile({ item, onOpen, search }) {
           onError={e => e.target.style.display = 'none'} />
       )}
       {hasTransfers && (
-        <span style={{ position: 'absolute', top: 6, right: 6, fontSize: 9,
+        <span style={{ position: 'absolute', top: 6, right: 6, fontSize: '0.69em',
           background: 'rgba(255,170,51,.2)', color: 'var(--sp)',
           border: '1px solid rgba(255,170,51,.3)', borderRadius: 4, padding: '1px 4px' }}>↔</span>
       )}
-      <div style={{ fontSize: 11, fontWeight: 600, lineHeight: 1.3, color: 'var(--tx)', marginBottom: 2 }}
+      <div style={{ fontSize: '0.85em', fontWeight: 600, lineHeight: 1.3, color: 'var(--tx)', marginBottom: 2 }}
         dangerouslySetInnerHTML={{ __html: highlight(item.name || '', search) }} />
       {item.item_type && (
-        <div style={{ fontSize: 9, color: 'var(--ci)', textTransform: 'uppercase', letterSpacing: '.04em' }}>
+        <div style={{ fontSize: '0.69em', color: 'var(--ci)', textTransform: 'uppercase', letterSpacing: '.04em' }}>
           {item.item_type}
         </div>
       )}
@@ -98,10 +98,10 @@ function CharBubble({ char, items, color, onColorChange, onDragStart, onDragOver
             style={{ width: 26, height: 26, borderRadius: '50%', objectFit: 'cover', border: `2px solid ${bubbleColor}` }}
             onError={e => e.target.style.display = 'none'} />
         )}
-        <div style={{ flex: 1, fontFamily: "'Cinzel',serif", fontSize: 12, fontWeight: 700, color: bubbleColor }}>
+        <div style={{ flex: 1, fontFamily: "'Cinzel',serif", fontSize: '0.92em', fontWeight: 700, color: bubbleColor }}>
           {name}
         </div>
-        <div style={{ fontSize: 10, color: 'var(--mut)' }}>{items.length} item{items.length !== 1 ? 's' : ''}</div>
+        <div style={{ fontSize: '0.77em', color: 'var(--mut)' }}>{items.length} item{items.length !== 1 ? 's' : ''}</div>
         {/* Color picker button */}
         <div style={{ position: 'relative' }}>
           <button
@@ -115,7 +115,7 @@ function CharBubble({ char, items, color, onColorChange, onDragStart, onDragOver
               background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 10,
               padding: 10, width: 160, boxShadow: '0 4px 20px rgba(0,0,0,.5)' }}
               onClick={e => e.stopPropagation()}>
-              <div style={{ fontSize: 9, color: 'var(--mut)', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '.05em' }}>Bubble Colour</div>
+              <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '.05em' }}>Bubble Colour</div>
               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5,1fr)', gap: 5, marginBottom: 8 }}>
                 {PRESET_COLORS.map(c => (
                   <button key={c} onClick={() => { onColorChange(c); setShowPicker(false) }}
@@ -128,7 +128,7 @@ function CharBubble({ char, items, color, onColorChange, onDragStart, onDragOver
                 onChange={e => onColorChange(e.target.value)}
                 style={{ width: '100%', height: 28, border: 'none', borderRadius: 6, cursor: 'pointer', background: 'none' }} />
               <button onClick={() => setShowPicker(false)}
-                style={{ marginTop: 6, width: '100%', fontSize: 10, padding: '3px 0',
+                style={{ marginTop: 6, width: '100%', fontSize: '0.77em', padding: '3px 0',
                   background: 'none', border: '1px solid var(--brd)', borderRadius: 6,
                   color: 'var(--mut)', cursor: 'pointer' }}>Done</button>
             </div>
@@ -138,7 +138,7 @@ function CharBubble({ char, items, color, onColorChange, onDragStart, onDragOver
 
       {/* Items grid inside bubble */}
       {items.length === 0 ? (
-        <div style={{ fontSize: 10, color: 'var(--mut)', padding: '8px 0', textAlign: 'center' }}>No items</div>
+        <div style={{ fontSize: '0.77em', color: 'var(--mut)', padding: '8px 0', textAlign: 'center' }}>No items</div>
       ) : (
         <div style={{ display: 'grid', gridTemplateColumns: `repeat(${cols}, minmax(0,1fr))`, gap: 6 }}>
           {items.map(item => (
@@ -167,8 +167,8 @@ function ItemPopup({ item, items, chars, db, onClose, onEdit, onTransfer, setLig
         maxHeight: '85vh', overflowY: 'auto' }}
         onClick={e => e.stopPropagation()}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 14 }}>
-          <div style={{ fontFamily: "'Cinzel',serif", fontSize: 15, color: tc, flex: 1 }}>{item.name}</div>
-          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 18, color: 'var(--mut)', marginLeft: 10 }}>✕</button>
+          <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.15em', color: tc, flex: 1 }}>{item.name}</div>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '1.38em', color: 'var(--mut)', marginLeft: 10 }}>✕</button>
         </div>
         {/* Image */}
         <div style={{ marginBottom: 14 }}>
@@ -180,18 +180,18 @@ function ItemPopup({ item, items, chars, db, onClose, onEdit, onTransfer, setLig
           ) : (
             <div style={{ width: '100%', height: 60, border: '1px dashed var(--brd)', borderRadius: 8,
               background: 'var(--card)', display: 'flex', alignItems: 'center', justifyContent: 'center',
-              color: 'var(--mut)', fontSize: 11 }}>No image</div>
+              color: 'var(--mut)', fontSize: '0.85em' }}>No image</div>
           )}
           <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
-            <label className="btn btn-sm btn-outline" style={{ cursor: 'pointer', fontSize: 10 }}>
+            <label className="btn btn-sm btn-outline" style={{ cursor: 'pointer', fontSize: '0.77em' }}>
               {uploadingImg === item.id ? 'Uploading…' : '⬆ Upload'}
               <input type="file" accept="image/*" style={{ display: 'none' }}
                 onChange={e => { const f = e.target.files[0]; if (f) handleImageUpload(item.id, f); e.target.value = '' }} />
             </label>
-            <button className="btn btn-sm btn-outline" style={{ fontSize: 10 }}
+            <button className="btn btn-sm btn-outline" style={{ fontSize: '0.77em' }}
               onClick={() => { onClose(); setPickerForItem(item.id) }}>🖼 Browse Library</button>
             {item.image && (
-              <button className="btn btn-sm btn-outline" style={{ fontSize: 10, color: '#ff3355', borderColor: '#ff335544' }}
+              <button className="btn btn-sm btn-outline" style={{ fontSize: '0.77em', color: '#ff3355', borderColor: '#ff335544' }}
                 onClick={() => { const it = items.find(x => x.id === item.id); if (it) db.upsertEntry('items', { ...it, image: null }) }}>Remove</button>
             )}
           </div>
@@ -202,23 +202,23 @@ function ItemPopup({ item, items, chars, db, onClose, onEdit, onTransfer, setLig
           ['Books', (item.books || []).join(', ')],
         ].filter(([, v]) => v).map(([label, val]) => (
           <div key={label} style={{ marginBottom: 8 }}>
-            <div style={{ fontSize: 9, fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>{label}</div>
-            <div style={{ fontSize: 12, color: 'var(--tx)' }}>{val}</div>
+            <div style={{ fontSize: '0.69em', fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>{label}</div>
+            <div style={{ fontSize: '0.92em', color: 'var(--tx)' }}>{val}</div>
           </div>
         ))}
-        {item.significance && <div style={{ marginBottom: 8 }}><div style={{ fontSize: 9, fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Significance</div><div style={{ fontSize: 12, color: 'var(--tx)', lineHeight: 1.6 }}>{item.significance}</div></div>}
-        {item.detail && <div style={{ marginBottom: 8 }}><div style={{ fontSize: 9, fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Detail</div><div style={{ fontSize: 12, color: 'var(--tx)', lineHeight: 1.6 }}>{item.detail}</div></div>}
+        {item.significance && <div style={{ marginBottom: 8 }}><div style={{ fontSize: '0.69em', fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Significance</div><div style={{ fontSize: '0.92em', color: 'var(--tx)', lineHeight: 1.6 }}>{item.significance}</div></div>}
+        {item.detail && <div style={{ marginBottom: 8 }}><div style={{ fontSize: '0.69em', fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Detail</div><div style={{ fontSize: '0.92em', color: 'var(--tx)', lineHeight: 1.6 }}>{item.detail}</div></div>}
         {(item.transfers || []).length > 0 && (
           <div style={{ marginTop: 10, paddingTop: 10, borderTop: '1px solid var(--brd)' }}>
-            <div style={{ fontSize: 9, fontWeight: 700, color: 'var(--sp)', textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 6 }}>↔ Transfer History</div>
+            <div style={{ fontSize: '0.69em', fontWeight: 700, color: 'var(--sp)', textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 6 }}>↔ Transfer History</div>
             {item.transfers.map((t, i) => (
-              <div key={i} style={{ fontSize: 11, color: 'var(--dim)', marginBottom: 3 }}>
+              <div key={i} style={{ fontSize: '0.85em', color: 'var(--dim)', marginBottom: 3 }}>
                 {t.from || '?'} → {t.to || '?'}{t.note ? ` · ${t.note}` : ''}{t.when ? <span style={{ color: 'var(--mut)' }}> ({t.when})</span> : ''}
               </div>
             ))}
           </div>
         )}
-        {item.notes && <div style={{ marginTop: 10, paddingTop: 10, borderTop: '1px solid var(--brd)', fontSize: 11, color: 'var(--dim)', lineHeight: 1.6 }}>{item.notes}</div>}
+        {item.notes && <div style={{ marginTop: 10, paddingTop: 10, borderTop: '1px solid var(--brd)', fontSize: '0.85em', color: 'var(--dim)', lineHeight: 1.6 }}>{item.notes}</div>}
         <div style={{ display: 'flex', gap: 8, marginTop: 16, justifyContent: 'flex-end' }}>
           <button className="btn btn-outline btn-sm" style={{ color: tc, borderColor: 'var(--ci)44' }}
             onClick={() => { onClose(); onEdit(item) }}>✎ Edit</button>
@@ -348,9 +348,9 @@ export default function Items({ db }) {
         <input className="sx" placeholder="Search items…" value={search} onChange={e => setSearch(e.target.value)} />
         <div style={{ display: 'flex', gap: 6 }}>
           <button className={`btn btn-sm btn-outline ${viewMode === 'holder' ? 'active' : ''}`}
-            style={{ fontSize: 10 }} onClick={() => setViewMode('holder')}>By Holder</button>
+            style={{ fontSize: '0.77em' }} onClick={() => setViewMode('holder')}>By Holder</button>
           <button className={`btn btn-sm btn-outline ${viewMode === 'list' ? 'active' : ''}`}
-            style={{ fontSize: 10 }} onClick={() => setViewMode('list')}>List</button>
+            style={{ fontSize: '0.77em' }} onClick={() => setViewMode('list')}>List</button>
         </div>
         <button className="btn btn-primary btn-sm" style={{ background: 'var(--ci)' }}
           onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add</button>
@@ -399,8 +399,8 @@ export default function Items({ db }) {
                 <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                   <div className="entry-title" dangerouslySetInnerHTML={{ __html: highlight(e.name || '', search) }} />
                   <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
-                    {(e.transfers || []).length > 0 && <span style={{ fontSize: 9, color: 'var(--sp)' }}>↔</span>}
-                    {e.holder && <div style={{ fontSize: 10, color: 'var(--ci)' }}>{holderName(e.holder)}</div>}
+                    {(e.transfers || []).length > 0 && <span style={{ fontSize: '0.69em', color: 'var(--sp)' }}>↔</span>}
+                    {e.holder && <div style={{ fontSize: '0.77em', color: 'var(--ci)' }}>{holderName(e.holder)}</div>}
                   </div>
                 </div>
                 <div className="entry-meta">
@@ -410,9 +410,9 @@ export default function Items({ db }) {
                 {isOpen && (
                   <>
                     <div className="entry-detail">
-                      {e.origin && <div style={{ marginBottom: 3 }}><strong style={{ color: 'var(--ci)', fontSize: 9, textTransform: 'uppercase' }}>Origin: </strong>{e.origin}</div>}
-                      {e.significance && <div style={{ marginBottom: 3 }}><strong style={{ color: 'var(--ci)', fontSize: 9, textTransform: 'uppercase' }}>Significance: </strong>{e.significance}</div>}
-                      {e.shared_with && <div style={{ marginBottom: 3 }}><strong style={{ color: 'var(--ci)', fontSize: 9, textTransform: 'uppercase' }}>Shared with: </strong>{holderName(e.shared_with)}</div>}
+                      {e.origin && <div style={{ marginBottom: 3 }}><strong style={{ color: 'var(--ci)', fontSize: '0.69em', textTransform: 'uppercase' }}>Origin: </strong>{e.origin}</div>}
+                      {e.significance && <div style={{ marginBottom: 3 }}><strong style={{ color: 'var(--ci)', fontSize: '0.69em', textTransform: 'uppercase' }}>Significance: </strong>{e.significance}</div>}
+                      {e.shared_with && <div style={{ marginBottom: 3 }}><strong style={{ color: 'var(--ci)', fontSize: '0.69em', textTransform: 'uppercase' }}>Shared with: </strong>{holderName(e.shared_with)}</div>}
                     </div>
                     <div className="entry-actions">
                       <button className="btn btn-sm btn-outline" style={{ color: 'var(--ci)', borderColor: 'var(--ci)' }} onClick={ev => { ev.stopPropagation(); setEditing(e); setModalOpen(true) }}>✎ Edit</button>

--- a/src/tabs/Scenes.jsx
+++ b/src/tabs/Scenes.jsx
@@ -311,7 +311,7 @@ export default function Scenes({ db, navSearch }) {
 
                               {/* Scene name */}
                               <div style={{
-                                fontSize: cardsPerRow === 'XS' ? '0.62em' : cardsPerRow === 'S' ? '0.69em' : '0.77em',
+                                fontSize: '0.77em',
                                 fontWeight: 600, color: 'var(--tx)', lineHeight: 1.3,
                                 overflow: 'hidden', display: '-webkit-box',
                                 WebkitLineClamp: 2,

--- a/src/tabs/Wardrobe.jsx
+++ b/src/tabs/Wardrobe.jsx
@@ -39,15 +39,15 @@ function WardrobeTile({ item, onOpen, search }) {
       onMouseEnter={e => e.currentTarget.style.borderColor = 'var(--cwr)'}
       onMouseLeave={e => e.currentTarget.style.borderColor = 'var(--brd)'}
     >
-      <div style={{ fontSize: 11, fontWeight: 600, lineHeight: 1.3, color: 'var(--tx)', marginBottom: 2 }}
+      <div style={{ fontSize: '0.85em', fontWeight: 600, lineHeight: 1.3, color: 'var(--tx)', marginBottom: 2 }}
         dangerouslySetInnerHTML={{ __html: highlight(item.name || '', search) }} />
       {item.item_type && (
-        <div style={{ fontSize: 9, color: tc, textTransform: 'uppercase', letterSpacing: '.04em' }}>
+        <div style={{ fontSize: '0.69em', color: tc, textTransform: 'uppercase', letterSpacing: '.04em' }}>
           {item.item_type}
         </div>
       )}
       {item.color_material && (
-        <div style={{ fontSize: 9, color: 'var(--mut)', marginTop: 2 }}>{item.color_material}</div>
+        <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 2 }}>{item.color_material}</div>
       )}
       {item.status && (
         <div style={{ marginTop: 3 }}>
@@ -69,13 +69,13 @@ function WardrobePopup({ item, color, onClose, onEdit, onDelete }) {
         borderRadius: 12, padding: 20, maxWidth: 420, width: '100%', maxHeight: '85vh', overflowY: 'auto' }}
         onClick={e => e.stopPropagation()}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 14 }}>
-          <div style={{ fontFamily: "'Cinzel',serif", fontSize: 15, color: tc, flex: 1 }}>{item.name}</div>
-          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 18, color: 'var(--mut)', marginLeft: 10 }}>✕</button>
+          <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.15em', color: tc, flex: 1 }}>{item.name}</div>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '1.38em', color: 'var(--mut)', marginLeft: 10 }}>✕</button>
         </div>
-        {item.item_type && <div style={{ marginBottom: 8 }}><div style={{ fontSize: 9, fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Type</div><div style={{ fontSize: 12, color: 'var(--tx)' }}>{item.item_type}</div></div>}
-        {item.color_material && <div style={{ marginBottom: 8 }}><div style={{ fontSize: 9, fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Color / Material</div><div style={{ fontSize: 12, color: 'var(--tx)' }}>{item.color_material}</div></div>}
-        {item.description && <div style={{ marginBottom: 8 }}><div style={{ fontSize: 9, fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Description</div><div style={{ fontSize: 12, color: 'var(--tx)', lineHeight: 1.6 }}>{item.description}</div></div>}
-        {item.notes && <div style={{ marginBottom: 8 }}><div style={{ fontSize: 9, fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Notes</div><div style={{ fontSize: 12, color: 'var(--dim)', lineHeight: 1.6 }}>{item.notes}</div></div>}
+        {item.item_type && <div style={{ marginBottom: 8 }}><div style={{ fontSize: '0.69em', fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Type</div><div style={{ fontSize: '0.92em', color: 'var(--tx)' }}>{item.item_type}</div></div>}
+        {item.color_material && <div style={{ marginBottom: 8 }}><div style={{ fontSize: '0.69em', fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Color / Material</div><div style={{ fontSize: '0.92em', color: 'var(--tx)' }}>{item.color_material}</div></div>}
+        {item.description && <div style={{ marginBottom: 8 }}><div style={{ fontSize: '0.69em', fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Description</div><div style={{ fontSize: '0.92em', color: 'var(--tx)', lineHeight: 1.6 }}>{item.description}</div></div>}
+        {item.notes && <div style={{ marginBottom: 8 }}><div style={{ fontSize: '0.69em', fontWeight: 700, color: tc, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 2 }}>Notes</div><div style={{ fontSize: '0.92em', color: 'var(--dim)', lineHeight: 1.6 }}>{item.notes}</div></div>}
         <div style={{ display: 'flex', gap: 8, marginTop: 16, justifyContent: 'flex-end' }}>
           <button className="btn btn-outline btn-sm" style={{ color: tc, borderColor: `${tc}44` }}
             onClick={() => { onClose(); onEdit(item) }}>✎ Edit</button>
@@ -123,8 +123,8 @@ function WardrobeBubble({ char, items, color, onColorChange, onDragStart, onDrag
             style={{ width: 26, height: 26, borderRadius: '50%', objectFit: 'cover', border: `2px solid ${bubbleColor}` }}
             onError={e => e.target.style.display = 'none'} />
         )}
-        <div style={{ flex: 1, fontFamily: "'Cinzel',serif", fontSize: 12, fontWeight: 700, color: bubbleColor }}>{name}</div>
-        <div style={{ fontSize: 10, color: 'var(--mut)' }}>{items.length} item{items.length !== 1 ? 's' : ''}</div>
+        <div style={{ flex: 1, fontFamily: "'Cinzel',serif", fontSize: '0.92em', fontWeight: 700, color: bubbleColor }}>{name}</div>
+        <div style={{ fontSize: '0.77em', color: 'var(--mut)' }}>{items.length} item{items.length !== 1 ? 's' : ''}</div>
         <div style={{ position: 'relative' }}>
           <button onClick={e => { e.stopPropagation(); setShowPicker(p => !p) }}
             title="Change bubble colour"
@@ -135,7 +135,7 @@ function WardrobeBubble({ char, items, color, onColorChange, onDragStart, onDrag
               background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 10,
               padding: 10, width: 160, boxShadow: '0 4px 20px rgba(0,0,0,.5)' }}
               onClick={e => e.stopPropagation()}>
-              <div style={{ fontSize: 9, color: 'var(--mut)', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '.05em' }}>Bubble Colour</div>
+              <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '.05em' }}>Bubble Colour</div>
               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5,1fr)', gap: 5, marginBottom: 8 }}>
                 {PRESET_COLORS.map(c => (
                   <button key={c} onClick={() => { onColorChange(c); setShowPicker(false) }}
@@ -146,7 +146,7 @@ function WardrobeBubble({ char, items, color, onColorChange, onDragStart, onDrag
               <input type="color" value={bubbleColor} onChange={e => onColorChange(e.target.value)}
                 style={{ width: '100%', height: 28, border: 'none', borderRadius: 6, cursor: 'pointer', background: 'none' }} />
               <button onClick={() => setShowPicker(false)}
-                style={{ marginTop: 6, width: '100%', fontSize: 10, padding: '3px 0',
+                style={{ marginTop: 6, width: '100%', fontSize: '0.77em', padding: '3px 0',
                   background: 'none', border: '1px solid var(--brd)', borderRadius: 6,
                   color: 'var(--mut)', cursor: 'pointer' }}>Done</button>
             </div>
@@ -154,7 +154,7 @@ function WardrobeBubble({ char, items, color, onColorChange, onDragStart, onDrag
         </div>
       </div>
       {items.length === 0 ? (
-        <div style={{ fontSize: 10, color: 'var(--mut)', padding: '8px 0', textAlign: 'center' }}>No wardrobe items</div>
+        <div style={{ fontSize: '0.77em', color: 'var(--mut)', padding: '8px 0', textAlign: 'center' }}>No wardrobe items</div>
       ) : (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(110px, 1fr))', gap: 6 }}>
           {items.map(item => (


### PR DESCRIPTION
### Motivation
- The root font scale is controlled by the `--fs` variable and the root/body `fontSize` which must affect all UI text (A+/A- feature). 
- Several tab components used hardcoded numeric `fontSize` values (pixels) in inline styles so they ignored the global scale. 
- Card-size pickers (XS/S/M/L/XL) should change layout density only and must not implicitly change typography.

### Description
- Confirmed global scaling is driven by `--fs` in `src/styles/globals.css` and `App.jsx` updates `--fs` plus `document.documentElement`/`body` fontSize via the `fontSize` state. 
- Replaced hardcoded numeric inline `fontSize` values with relative `em`-based values in affected tabs so text follows the root font size: `src/tabs/FamilyTree.jsx`, `src/tabs/Inventory.jsx`, `src/tabs/Wardrobe.jsx`, `src/tabs/Items.jsx`, `src/tabs/Flags.jsx`. 
- Audited card-size pickers and decoupled font sizing from layout density by removing size-dependent font rules in `src/tabs/Scenes.jsx` and ensuring the XS/S/M/L/XL controls only change grid/column counts or widths. 
- Kept all layout dimensions (widths, heights, paddings, spacing) unchanged; only `fontSize` inline values were updated to `em` strings to respect the global scale.

### Testing
- Ran `npm run build` and the production build completed successfully using Vite. 
- Observed non-blocking Vite warnings about chunk size and a dynamic-import reporter note; these are informational and did not prevent a successful build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e0c76840832e86afbf40fa578160)