### PR TITLE
Session import fix + Notes restructure + Manuscript M2 + Review Queue + PR #13 polish (bug fixes, em-conversion, tab colors, Ideas sub-tab, Items sub-tab, Dashboard search, nav icons)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
-// Guardians of Lajen Compendium — Service Worker v15
-const CACHE_NAME = 'gol-compendium-v16';
+// Guardians of Lajen Compendium — Service Worker v17
+const CACHE_NAME = 'gol-compendium-v17';
 const PRECACHE_URLS = ['/', '/index.html', '/icon-192.png', '/icon-512.png'];
 
 self.addEventListener('install', event => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,9 +31,9 @@ import IOBar from './components/common/IOBar'
 
 const TAB_ORDER = [
   'dashboard','wiki','glossary','characters','familytree','world','locations','map',
-  'manuscript','scenes','timeline','eras','calendar',
-  'inventory','wardrobe','items','flags','questions','canon','spellings',
-  'notes','journal','tools','sessionlog'
+  'manuscript','scenes','timeline','calendar',
+  'inventory','flags','questions','canon','spellings',
+  'notes','tools','sessionlog'
 ]
 
 const VALID_TABS = new Set(TAB_ORDER)
@@ -232,8 +232,6 @@ export default function App() {
     switch (tab) {
       case 'dashboard':  return <Dashboard {...tabProps} />
       case 'characters': return <Characters {...tabProps} />
-      case 'wardrobe':   return <Wardrobe {...tabProps} />
-      case 'items':      return <Items {...tabProps} />
       case 'locations':  return <Locations {...tabProps} />
       case 'timeline':   return <Timeline {...tabProps} />
       case 'scenes':     return <Scenes {...tabProps} />
@@ -242,12 +240,10 @@ export default function App() {
       case 'canon':      return <Canon {...tabProps} />
       case 'world':      return <World {...tabProps} />
       case 'questions':  return <Questions {...tabProps} />
-      case 'eras':       return <Eras {...tabProps} />
       case 'spellings':  return <Spellings {...tabProps} />
       case 'map':        return <MapTab {...tabProps} />
       case 'wiki':       return <Wiki {...tabProps} />
       case 'notes':      return <Notes {...tabProps} />
-      case 'journal':    return <Journal {...tabProps} />
       case 'familytree': return <FamilyTree {...tabProps} />
       case 'flags':      return <Flags {...tabProps} />
       case 'manuscript': return <Manuscript {...tabProps} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -202,7 +202,7 @@ export default function App() {
         setConflictQueue(result.conflicts)
         setImportSummary({ added: result.added, resolved: 0, total: result.conflicts.length })
       } else {
-        setImportSummary({ added: result.added, resolved: 0, total: 0, done: true })
+        setImportSummary({ added: result.added + (result.sessionLogAdded || 0), resolved: 0, total: 0, done: true })
       }
     } catch (err) { setImportSummary({ error: err.message, done: true }) }
   }, [db])

--- a/src/components/common/AlphabetJumpBar.jsx
+++ b/src/components/common/AlphabetJumpBar.jsx
@@ -1,0 +1,42 @@
+import { useMemo } from 'react'
+
+const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
+
+export default function AlphabetJumpBar({ entries, getName, onJump, color = 'var(--cc)' }) {
+  const available = useMemo(() => {
+    const set = new Set()
+    entries.forEach(e => {
+      const name = (getName(e) || '').trim()
+      if (!name) return
+      const letter = name[0].toUpperCase()
+      if (LETTERS.includes(letter)) set.add(letter)
+    })
+    return set
+  }, [entries, getName])
+
+  function jumpTo(letter) {
+    const target = entries.find(e => {
+      const name = (getName(e) || '').trim()
+      return name[0]?.toUpperCase() === letter
+    })
+    if (target) onJump(target)
+  }
+
+  return (
+    <div style={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center', padding: '6px 8px', background: 'var(--card)', borderRadius: 6, border: '1px solid var(--brd)', marginBottom: 8, position: 'sticky', top: 0, zIndex: 10 }}>
+      {LETTERS.map(L => {
+        const has = available.has(L)
+        return (
+          <button
+            key={L}
+            onClick={() => has && jumpTo(L)}
+            disabled={!has}
+            style={{ fontSize: '0.77em', padding: '2px 7px', minWidth: 22, borderRadius: 4, border: 'none', background: 'none', color: has ? color : 'var(--mut)', cursor: has ? 'pointer' : 'default', opacity: has ? 1 : 0.3, fontWeight: has ? 700 : 400 }}
+          >
+            {L}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/common/GenericListTab.jsx
+++ b/src/components/common/GenericListTab.jsx
@@ -1,63 +1,69 @@
-const SIZE_COLS = { XS: 5, S: 4, M: 3, L: 2, XL: 1 }
-
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import Modal from './Modal'
 import EntryForm from './EntryForm'
+import AlphabetJumpBar from './AlphabetJumpBar'
 import { SL, highlight } from '../../constants'
-import { uid } from '../../constants'
+import { scrollAndFlashEntry } from './entryNav'
+
+const SIZE_COLS = { XS: 5, S: 4, M: 3, L: 2, XL: 1 }
 
 export default function GenericListTab({
   catKey, color, icon, label, fields, db,
   renderDetail, extraActions,
   columns, columnRule,
-  crossLink, clearCrossLink
+  navSearch,
+  getJumpName,
 }) {
   const entries = db.db[catKey] || []
   const [search, setSearch] = useState('')
   const [colSize, setColSize] = useState(() => {
     try { return localStorage.getItem(`colsize_${label}`) || 'M' } catch { return 'M' }
   })
-  const cols = SIZE_COLS[colSize] || 3
-
-  function changeColSize(sz) {
-    setColSize(sz)
-    try { localStorage.setItem(`colsize_${label}`, sz) } catch {}
-  }
-  const [fB, setFB] = useState('all')
   const [fS, setFS] = useState('all')
   const [expanded, setExpanded] = useState(null)
   const [modalOpen, setModalOpen] = useState(false)
   const [editing, setEditing] = useState(null)
   const [confirmId, setConfirmId] = useState(null)
   const [sortMode, setSortMode] = useState('alpha')
+  const [autoOnly, setAutoOnly] = useState(false)
+  const cols = SIZE_COLS[colSize] || 3
+  const autoCount = entries.filter(e => e.auto_imported === true).length
 
-  // Consume crossLink: pre-populate search and expand matching entry
+  useEffect(() => { setSearch(navSearch || '') }, [navSearch])
+
   useEffect(() => {
-    if (crossLink?.search) {
-      setSearch(crossLink.search)
-      if (crossLink.expandId) {
-        setExpanded(crossLink.expandId)
-      } else if (crossLink.expandName) {
-        const match = entries.find(e =>
-          (e.name || e.display_name || '').toLowerCase() === crossLink.expandName.toLowerCase()
-        )
-        if (match) setExpanded(match.id)
-      }
-      clearCrossLink?.()
+    function onExpand(e) {
+      const targetId = e?.detail?.id
+      if (!targetId) return
+      const entry = entries.find(x => x.id === targetId)
+      if (!entry) return
+      setExpanded(targetId)
+      setEditing(entry)
+      setModalOpen(true)
+      window.setTimeout(() => scrollAndFlashEntry(targetId), 50)
     }
-  }, [crossLink])
+    window.addEventListener('gcomp_expand', onExpand)
+    return () => window.removeEventListener('gcomp_expand', onExpand)
+  }, [entries])
+
+  function changeColSize(sz) {
+    setColSize(sz)
+    try { localStorage.setItem(`colsize_${label}`, sz) } catch {}
+  }
 
   const filtered = entries
     .filter(e => {
       const matchSearch = !search || JSON.stringify(e).toLowerCase().includes(search.toLowerCase())
-      const matchBook = fB === 'all' || (e.books || []).includes(fB)
       const matchStatus = fS === 'all' || e.status === fS
-      return matchSearch && matchBook && matchStatus
+      const matchAuto = !autoOnly || e.auto_imported === true
+      return matchSearch && matchStatus && matchAuto
     })
     .sort((a, b) => {
-      if (sortMode === 'alpha') return (a.display_name || a.name || '').localeCompare(b.display_name || b.name || '')
-      if (sortMode === 'newest') return new Date(b.created || 0) - new Date(a.created || 0)
-      if (sortMode === 'oldest') return new Date(a.created || 0) - new Date(b.created || 0)
+      const aName = a.display_name || a.name || a.word || ''
+      const bName = b.display_name || b.name || b.word || ''
+      if (sortMode === 'alpha') return aName.localeCompare(bName)
+      if (sortMode === 'newest') return new Date(b.updated_at || b.updated || b.created || 0) - new Date(a.updated_at || a.updated || a.created || 0)
+      if (sortMode === 'oldest') return new Date(a.updated_at || a.updated || a.created || 0) - new Date(b.updated_at || b.updated || b.created || 0)
       return 0
     })
 
@@ -66,23 +72,11 @@ export default function GenericListTab({
   function closeModal() { setModalOpen(false); setEditing(null) }
 
   function handleSave(entry) {
-    // Duplicate detection — new entries only
-    if (!editing?.id) {
-      const newName = (entry.name || entry.display_name || '').toLowerCase().trim()
-      if (newName) {
-        const dupe = entries.find(e =>
-          e.id !== entry.id &&
-          (e.name || e.display_name || '').toLowerCase().trim() === newName
-        )
-        if (dupe && !window.confirm(`"${dupe.name || dupe.display_name}" already exists in ${label}. Save anyway?`)) return
-      }
-    }
-    // Stamp updated_at
     const stamped = { ...entry, updated_at: new Date().toISOString() }
     if (!editing?.id) stamped.created = stamped.created || stamped.updated_at
     db.upsertEntry(catKey, stamped)
     closeModal()
-    setExpanded(entry.id)
+    setExpanded(stamped.id)
   }
 
   function handleDelete(id) {
@@ -93,142 +87,87 @@ export default function GenericListTab({
 
   function badges(e) {
     const parts = []
-    if (e.status) parts.push(
-      <span key="s" className={`badge badge-${e.status}`}>{SL[e.status]}</span>
-    )
-    ;(e.books || []).forEach(b => parts.push(
-      <span key={b} className="badge badge-book">{b}</span>
-    ))
-    if (e.flagged) parts.push(
-      <span key="f" className="badge badge-flag">🚩</span>
-    )
+    if (e.status) parts.push(<span key="s" className={`badge badge-${e.status}`}>{SL[e.status]}</span>)
+    if (e.flagged) parts.push(<span key="f" className="badge badge-flag">🚩</span>)
+    if (e.auto_imported) parts.push(<span key="a" className="badge" style={{ color: '#ffcc00', borderColor: 'rgba(255,204,0,.35)' }}>📥 Auto-imported</span>)
     return parts
   }
 
   function fmtDate(iso) {
     if (!iso) return null
-    try { return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }) }
-    catch { return null }
+    try { return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }) } catch { return null }
   }
 
-  // Masonry column layout if columns prop provided
-  const listStyle = columns && columns > 1
-    ? { columns, columnGap: 10, columnRule: columnRule || 'none' }
-    : {}
+  const listStyle = columns && columns > 1 ? { columns, columnGap: 10, columnRule: columnRule || 'none' } : {}
 
   return (
     <div>
-      {/* Toolbar */}
       <div className="tbar">
         <div style={{ display: 'flex', gap: 3 }}>
-          {['XS','S','M','L','XL'].map(sz => (
-            <button key={sz} onClick={() => changeColSize(sz)}
-              style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, cursor: 'pointer',
-                background: colSize === sz ? color : 'none',
-                color: colSize === sz ? '#000' : 'var(--dim)',
-                border: `1px solid ${colSize === sz ? color : 'var(--brd)'}` }}>{sz}</button>
+          {['XS', 'S', 'M', 'L', 'XL'].map(sz => (
+            <button key={sz} onClick={() => changeColSize(sz)} style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, cursor: 'pointer', background: colSize === sz ? color : 'none', color: colSize === sz ? '#000' : 'var(--dim)', border: `1px solid ${colSize === sz ? color : 'var(--brd)'}` }}>{sz}</button>
           ))}
         </div>
-        <input
-          className="sx"
-          placeholder="Search…"
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-        />
-        <select
-          value={sortMode}
-          onChange={e => setSortMode(e.target.value)}
-          style={{ fontSize: 'var(--fs-xs)', padding: '4px 8px', borderRadius: 'var(--r)', border: '1px solid var(--brd)', background: 'var(--sf)', color: 'var(--dim)', cursor: 'pointer' }}
-          title="Sort order"
-        >
+        <input className="sx" placeholder="Search..." value={search} onChange={e => setSearch(e.target.value)} />
+        {autoCount > 0 && (
+          <button onClick={() => setAutoOnly(v => !v)} style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: `1px solid ${autoOnly ? '#ffcc00' : 'var(--brd)'}`, background: autoOnly ? '#ffcc0022' : 'none', color: autoOnly ? '#ffcc00' : 'var(--dim)', cursor: 'pointer' }}>
+            📥 Auto-imported ({autoCount})
+          </button>
+        )}
+        <select value={sortMode} onChange={e => setSortMode(e.target.value)} style={{ fontSize: 'var(--fs-xs)', padding: '4px 8px', borderRadius: 'var(--r)', border: '1px solid var(--brd)', background: 'var(--sf)', color: 'var(--dim)', cursor: 'pointer' }} title="Sort order">
           <option value="alpha">A → Z</option>
           <option value="newest">Newest first</option>
           <option value="oldest">Oldest first</option>
         </select>
-        <button
-          className="btn btn-primary btn-sm"
-          style={{ background: color }}
-          onClick={openAdd}
-        >+ Add</button>
+        <button className="btn btn-primary btn-sm" style={{ background: color }} onClick={openAdd}>+ Add</button>
       </div>
 
-      {/* Filter pills */}
       <div className="tbar" style={{ paddingTop: 0 }}>
         <div className="filter-group">
-          {['all','locked','provisional','open','exploratory'].map(s => (
-            <button
-              key={s}
-              className={`fp ${fS === s ? 'active' : ''}`}
-              style={s !== 'all' ? { color: `var(--s${s[0]})` } : {}}
-              onClick={() => setFS(s)}
-            >
+          {['all', 'locked', 'provisional', 'open', 'exploratory'].map(s => (
+            <button key={s} className={`fp ${fS === s ? 'active' : ''}`} style={s !== 'all' ? { color: `var(--s${s[0]})` } : {}} onClick={() => setFS(s)}>
               {s === 'all' ? 'All statuses' : SL[s]}
             </button>
           ))}
         </div>
       </div>
 
-      {/* List */}
+      {getJumpName && filtered.length > 0 && (
+        <AlphabetJumpBar entries={filtered} getName={getJumpName} onJump={target => scrollAndFlashEntry(target.id)} color={color} />
+      )}
+
       <div className="cg" style={listStyle}>
         {!filtered.length && (
           <div className="empty">
             <div className="empty-icon">{icon}</div>
             <p>No {label.toLowerCase()} yet.</p>
-            <button className="btn btn-primary" style={{ background: color }} onClick={openAdd}>
-              + Add {label.slice(0,-1)}
-            </button>
+            <button className="btn btn-primary" style={{ background: color }} onClick={openAdd}>+ Add {label.slice(0, -1)}</button>
           </div>
         )}
         {filtered.map((e, i) => {
           const isOpen = expanded === e.id
-          const ts = e.updated_at || e.created
+          const ts = e.updated_at || e.updated || e.created
           return (
-            <div
-              key={e.id}
-              className="entry-card"
-              style={{
-                '--card-color': color,
-                background: i % 2 === 1 ? 'rgba(255,255,255,.01)' : undefined,
-                breakInside: 'avoid', marginBottom: 6,
-              }}
-              onClick={() => setExpanded(isOpen ? null : e.id)}
-            >
-              <div
-                className="entry-title"
-                dangerouslySetInnerHTML={{ __html: highlight(e.display_name || e.name || '', search) }}
-              />
+            <div key={e.id} id={`gcomp-entry-${e.id}`} className="entry-card" style={{ '--card-color': color, background: i % 2 === 1 ? 'rgba(255,255,255,.01)' : undefined, breakInside: 'avoid', marginBottom: 6 }} onClick={() => setExpanded(isOpen ? null : e.id)}>
+              <div className="entry-title" dangerouslySetInnerHTML={{ __html: highlight(e.display_name || e.name || e.word || '', search) }} />
               <div className="entry-meta">{badges(e)}</div>
 
               {isOpen && (
                 <>
                   <div className="entry-detail">
-                    {renderDetail ? renderDetail(e) : (
-                      fields.filter(f => f.k !== 'name' && e[f.k]).map(f => (
-                        <div key={f.k} style={{ marginBottom: 3 }}>
-                          <strong style={{ color, fontSize: 'var(--fs-xs)', textTransform: 'uppercase' }}>{f.l}: </strong>
-                          {String(e[f.k])}
-                        </div>
-                      ))
-                    )}
+                    {renderDetail ? renderDetail(e) : fields.filter(f => f.k !== 'name' && e[f.k]).map(f => (
+                      <div key={f.k} style={{ marginBottom: 3 }}>
+                        <strong style={{ color, fontSize: 'var(--fs-xs)', textTransform: 'uppercase' }}>{f.l}: </strong>
+                        {String(e[f.k])}
+                      </div>
+                    ))}
                   </div>
                   {e.notes && <div className="entry-notes">{e.notes}</div>}
-                  {ts && (
-                    <div className="entry-timestamp">
-                      {e.updated_at && e.updated_at !== e.created ? `Edited ${fmtDate(e.updated_at)}` : e.created ? `Added ${fmtDate(e.created)}` : ''}
-                    </div>
-                  )}
+                  {ts && <div className="entry-timestamp">{e.updated_at && e.updated_at !== e.created ? `Edited ${fmtDate(e.updated_at)}` : e.created ? `Added ${fmtDate(e.created)}` : ''}</div>}
                   <div className="entry-actions">
-                    <button
-                      className="btn btn-sm btn-outline"
-                      style={{ color, borderColor: color }}
-                      onClick={ev => { ev.stopPropagation(); openEdit(e) }}
-                    >✎ Edit</button>
+                    <button className="btn btn-sm btn-outline" style={{ color, borderColor: color }} onClick={ev => { ev.stopPropagation(); openEdit(e) }}>✎ Edit</button>
                     {extraActions && extraActions(e)}
-                    <button
-                      className="btn btn-sm btn-outline"
-                      style={{ color: '#ff3355', borderColor: '#ff335544' }}
-                      onClick={ev => { ev.stopPropagation(); setConfirmId(e.id) }}
-                    >✕</button>
+                    <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544' }} onClick={ev => { ev.stopPropagation(); setConfirmId(e.id) }}>✕</button>
                   </div>
                 </>
               )}
@@ -237,31 +176,14 @@ export default function GenericListTab({
         })}
       </div>
 
-      {/* Add/Edit modal */}
-      <Modal
-        open={modalOpen}
-        onClose={closeModal}
-        title={`${editing?.id ? 'Edit' : 'Add'} ${label.slice(0,-1)}`}
-        color={color}
-      >
-        <EntryForm
-          fields={fields}
-          entry={editing || {}}
-          onSave={handleSave}
-          onCancel={closeModal}
-          color={color}
-          label={label}
-          db={db}
-        />
+      <Modal open={modalOpen} onClose={closeModal} title={`${editing?.id ? 'Edit' : 'Add'} ${label.slice(0, -1)}`} color={color}>
+        <EntryForm fields={fields} entry={editing || {}} onSave={handleSave} onCancel={closeModal} color={color} label={label} db={db} />
       </Modal>
 
-      {/* Confirm delete */}
       {confirmId && (
         <div className="confirm-overlay open">
           <div className="confirm-box">
-            <p>Delete <strong>{entries.find(e=>e.id===confirmId)?.name || 'this entry'}</strong>?<br/>
-              <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--mut)' }}>Cannot be undone.</span>
-            </p>
+            <p>Delete <strong>{entries.find(e => e.id === confirmId)?.name || 'this entry'}</strong>?<br /><span style={{ fontSize: 'var(--fs-xs)', color: 'var(--mut)' }}>Cannot be undone.</span></p>
             <button className="btn btn-outline btn-sm" onClick={() => setConfirmId(null)}>Cancel</button>{' '}
             <button className="btn btn-danger btn-sm" onClick={() => handleDelete(confirmId)}>Delete</button>
           </div>

--- a/src/components/common/entryNav.js
+++ b/src/components/common/entryNav.js
@@ -1,0 +1,9 @@
+export function scrollAndFlashEntry(id) {
+  const el = document.getElementById(`gcomp-entry-${id}`)
+  if (!el) return
+  el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  const orig = el.style.background
+  el.style.transition = 'background 0.3s'
+  el.style.background = 'rgba(255, 220, 100, 0.4)'
+  window.setTimeout(() => { el.style.background = orig }, 1500)
+}

--- a/src/hooks/useDB.js
+++ b/src/hooks/useDB.js
@@ -262,7 +262,7 @@ export function useDB() {
   const importJSON = useCallback((file) => {
     return new Promise((resolve, reject) => {
       const r = new FileReader()
-      r.onload = ev => {
+      r.onload = async ev => {
         try {
           const parsed = JSON.parse(ev.target.result)
           let added = 0; const conflicts = []
@@ -279,7 +279,16 @@ export function useDB() {
             })
             lsSave(next); return next
           })
-          resolve({ added, conflicts })
+          // Handle session_log - stored in its own Supabase table, not in CATEGORIES
+          let sessionLogAdded = 0
+          if (parsed.session_log && Array.isArray(parsed.session_log) && hasSupabase) {
+            for (const entry of parsed.session_log) {
+              if (!entry?.id) continue
+              const { error } = await supabase.from('session_log').upsert(entry, { onConflict: 'id', ignoreDuplicates: true })
+              if (!error) sessionLogAdded++
+            }
+          }
+          resolve({ added, conflicts, sessionLogAdded })
         } catch (e) { reject(e) }
       }
       r.readAsText(file)

--- a/src/tabs/Canon.jsx
+++ b/src/tabs/Canon.jsx
@@ -1,25 +1,21 @@
 import GenericListTab from '../components/common/GenericListTab'
 
 const CANON_FIELDS = [
-  { k: 'name',    l: 'Decision', t: 'text', r: true },
-  { k: 'session', l: 'Session',  t: 'text' },
-  { k: 'detail',  l: 'Detail',   t: 'ta' },
-]
-
-const CANON_FILTERS = [
-  { key: 'status', label: 'Status', options: [
-    { value: 'locked', label: 'Locked' },
-    { value: 'provisional', label: 'Provisional' },
-    { value: 'open', label: 'Open' },
-  ]},
+  { k: 'name', l: 'Decision', t: 'text', r: true },
+  { k: 'session', l: 'Session', t: 'text' },
+  { k: 'detail', l: 'Detail', t: 'ta' },
 ]
 
 export default function Canon({ db, navSearch }) {
   return (
     <GenericListTab
-      catKey="canon" color="#ff48c4" icon="✦"
-      label="Canon Decisions" fields={CANON_FIELDS} db={db}
-      navSearch={navSearch} extraFilters={CANON_FILTERS}
+      catKey="canon"
+      color="#ff48c4"
+      icon="✦"
+      label="Canon Decisions"
+      fields={CANON_FIELDS}
+      db={db}
+      navSearch={navSearch}
     />
   )
 }

--- a/src/tabs/Characters.jsx
+++ b/src/tabs/Characters.jsx
@@ -3,6 +3,8 @@ const SIZE_COLS_CHARS = { XS: 4, S: 3, M: 2, L: 1, XL: 1 }
 import { useState, useRef, useEffect, useCallback } from 'react'
 import Modal from '../components/common/Modal'
 import EntryForm from '../components/common/EntryForm'
+import AlphabetJumpBar from '../components/common/AlphabetJumpBar'
+import { scrollAndFlashEntry } from '../components/common/entryNav'
 import { CHAR_FIELDS, highlight, SL, uid, hexToRgba, lerpColor } from '../constants'
 import FilterPopup from '../components/common/FilterPopup'
 
@@ -82,6 +84,21 @@ export default function Characters({ db, goTo, tab, navSearch }) {
   const [portraitCharId, setPortraitCharId] = useState(null)
   const [lightboxSrc, setLightboxSrc] = useState(null)
   const [filterDeceased, setFilterDeceased] = useState('all') // 'all'|'alive'|'deceased'
+  const [autoOnly, setAutoOnly] = useState(false)
+  const autoCount = chars.filter(c => c.auto_imported === true).length
+
+  useEffect(() => {
+    function onExpand(e) {
+      const targetId = e?.detail?.id
+      if (!targetId) return
+      const entry = chars.find(x => x.id === targetId)
+      if (!entry) return
+      setExpanded(targetId)
+      window.setTimeout(() => scrollAndFlashEntry(targetId), 50)
+    }
+    window.addEventListener('gcomp_expand', onExpand)
+    return () => window.removeEventListener('gcomp_expand', onExpand)
+  }, [chars])
 
   // filterDeceased can be 'all', 'alive', 'deceased', or a book name like 'Book 1'
   const filtered = chars.filter(e => {
@@ -91,6 +108,7 @@ export default function Characters({ db, goTo, tab, navSearch }) {
     } else if (filterDeceased === 'deceased') {
       if (isDeceased(e) !== true) return false
     }
+    if (autoOnly && e.auto_imported !== true) return false
     return true
   })
 
@@ -215,8 +233,15 @@ export default function Characters({ db, goTo, tab, navSearch }) {
           values={filterValues}
           onChange={(key, vals) => setFilterValues(prev => ({ ...prev, [key]: vals }))}
         />
+        {autoCount > 0 && (
+          <button onClick={() => setAutoOnly(v => !v)} style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: `1px solid ${autoOnly ? '#ffcc00' : 'var(--brd)'}`, background: autoOnly ? '#ffcc0022' : 'none', color: autoOnly ? '#ffcc00' : 'var(--dim)', cursor: 'pointer' }}>
+            📥 Auto-imported ({autoCount})
+          </button>
+        )}
         <button className="btn btn-primary btn-sm" style={{ background: '#e63946' }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add</button>
       </div>
+
+      <AlphabetJumpBar entries={filtered} getName={c => c.display_name || c.name} onJump={target => scrollAndFlashEntry(target.id)} color="#e63946" />
 
       <div className="cg">
         {!filtered.length && (
@@ -233,7 +258,7 @@ export default function Characters({ db, goTo, tab, navSearch }) {
           const dead = isDeceased(e)
 
           return (
-            <div key={e.id} className="entry-card"
+            <div key={e.id} id={`gcomp-entry-${e.id}`} className="entry-card"
               style={{
                 '--card-color': 'var(--cc)',
                 background: dead === true ? 'rgba(255,51,85,.03)' : i%2===1 ? 'rgba(255,255,255,.01)' : undefined,

--- a/src/tabs/Dashboard.jsx
+++ b/src/tabs/Dashboard.jsx
@@ -40,7 +40,7 @@ export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch
   Object.entries(data).forEach(([cat, entries]) => {
     if (!Array.isArray(entries) || !CATS[cat]) return
     entries.forEach(e => {
-      const ts = e.updated_at || e.updated || e.created
+      const ts = e.updated_at || e.updated || e.created_at || e.created
       if (ts) recent.push({ cat, name: e.name || e.title || e.display_name || e.word || '(unnamed)', ts, id: e.id })
     })
   })

--- a/src/tabs/Dashboard.jsx
+++ b/src/tabs/Dashboard.jsx
@@ -1,19 +1,21 @@
-import { useState, useRef } from 'react'
+import { useRef, useState } from 'react'
 import { CATS, TAB_RAINBOW } from '../constants'
 
 const TAB_LIST = [
-  'wiki','glossary','characters','familytree','world','locations','map',
-  'manuscript','scenes','timeline','eras','calendar',
-  'inventory','wardrobe','items','flags','questions','canon','spellings',
-  'notes','journal','tools','sessionlog'
+  'wiki', 'glossary', 'characters', 'familytree', 'world', 'locations', 'map',
+  'manuscript', 'scenes', 'timeline', 'calendar',
+  'inventory', 'flags', 'questions', 'canon', 'spellings',
+  'notes', 'tools', 'sessionlog',
 ]
 
 const RAINBOW = [
-  '#ff69b4','#ff6b6b','#e63946','#f4442e','#ff8c00','#ffb700','#ffd600',
-  '#aacc00','#38b000','#0fb5a0','#00b4d8','#4cc9f0','#3a86ff','#4361ee',
-  '#7b2d8b','#9d4edd','#c77dff','#ff48c4'
+  '#ff69b4', '#ff6b6b', '#e63946', '#f4442e', '#ff8c00', '#ffb700', '#ffd600',
+  '#aacc00', '#38b000', '#0fb5a0', '#00b4d8', '#4cc9f0', '#3a86ff', '#4361ee',
+  '#7b2d8b', '#9d4edd', '#c77dff', '#ff48c4',
 ]
-const rc = (i) => RAINBOW[i % RAINBOW.length]
+
+const REVIEW_CATS = ['characters', 'locations', 'items', 'scenes', 'timeline', 'wiki', 'world', 'glossary', 'spellings', 'canon', 'flags', 'questions', 'notes']
+const rc = i => RAINBOW[i % RAINBOW.length]
 
 export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch }) {
   const { db: data } = db
@@ -22,7 +24,10 @@ export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch
   })
   const imgRef = useRef(null)
 
-  let tot = 0, lk = 0, pv = 0, op = 0
+  let tot = 0
+  let lk = 0
+  let pv = 0
+  let op = 0
   const fl = (data.flags || []).length
 
   Object.keys(CATS).forEach(c => {
@@ -35,7 +40,6 @@ export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch
     })
   })
 
-  // Recent entries across all categories
   const recent = []
   Object.entries(data).forEach(([cat, entries]) => {
     if (!Array.isArray(entries) || !CATS[cat]) return
@@ -46,8 +50,40 @@ export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch
   })
   recent.sort((a, b) => new Date(b.ts) - new Date(a.ts))
 
-  const questions = (data.questions || []).filter(q => q.status === 'open').slice(0, 10)
-  const flags = (data.flags || []).slice(0, 10)
+  let reviewCount = 0
+  const reviewItems = []
+  REVIEW_CATS.forEach(cat => {
+    if (cat === 'glossary') {
+      ;(data.wiki || []).forEach(e => {
+        if (e.auto_imported === true && e.is_glossary) {
+          reviewCount++
+          reviewItems.push({
+            cat: 'glossary',
+            name: e.title || e.name || '(unnamed)',
+            id: e.id,
+            source: e.source || 'unknown',
+            updated: e.updated || e.updated_at || e.created_at || e.created,
+          })
+        }
+      })
+      return
+    }
+    ;(data[cat] || []).forEach(e => {
+      if (e.auto_imported === true) {
+        reviewCount++
+        reviewItems.push({
+          cat,
+          name: e.name || e.title || e.term || e.word || e.display_name || e.text?.slice(0, 50) || '(unnamed)',
+          id: e.id,
+          source: e.source || 'unknown',
+          updated: e.updated || e.updated_at || e.created_at || e.created,
+        })
+      }
+    })
+  })
+  reviewItems.sort((a, b) => new Date(b.updated || 0) - new Date(a.updated || 0))
+
+  const flags = (data.flags || []).slice(0, 14)
 
   function handleHeaderImg(e) {
     const file = e.target.files?.[0]
@@ -62,31 +98,26 @@ export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch
   }
 
   const panelRow = (item, i, color, onClick) => (
-    <div key={item.id || i} onClick={onClick}
-      style={{ padding: '4px 6px', borderRadius: 4, cursor: 'pointer', marginBottom: 2,
-        background: i % 2 === 0 ? 'var(--card)' : 'transparent',
-        borderLeft: `2px solid ${color}`, minWidth: 0, overflow: 'hidden' }}
-      onMouseEnter={e => e.currentTarget.style.background = 'rgba(255,255,255,.06)'}
-      onMouseLeave={e => e.currentTarget.style.background = i % 2 === 0 ? 'var(--card)' : 'transparent'}>
-      <div style={{ fontSize: '0.85em', color: 'var(--tx)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-        {item.name}
-      </div>
+    <div
+      key={item.id || i}
+      onClick={onClick}
+      style={{ padding: '4px 6px', borderRadius: 4, cursor: 'pointer', marginBottom: 2, background: i % 2 === 0 ? 'var(--card)' : 'transparent', borderLeft: `2px solid ${color}`, minWidth: 0, overflow: 'hidden' }}
+      onMouseEnter={e => { e.currentTarget.style.background = 'rgba(255,255,255,.06)' }}
+      onMouseLeave={e => { e.currentTarget.style.background = i % 2 === 0 ? 'var(--card)' : 'transparent' }}
+    >
+      <div style={{ fontSize: '0.85em', color: 'var(--tx)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{item.name}</div>
       {item.detail && <div style={{ fontSize: '0.69em', color: 'var(--mut)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{item.detail}</div>}
-      {item.cat && <div style={{ fontSize: '0.69em', color: color, opacity: 0.8, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{CATS[item.cat]?.i} {CATS[item.cat]?.l}</div>}
+      {item.cat && <div style={{ fontSize: '0.69em', color, opacity: 0.8, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{CATS[item.cat]?.i} {CATS[item.cat]?.l}</div>}
     </div>
   )
 
   const panelHead = (icon, label, color, count) => (
-    <div style={{ fontSize: '0.77em', fontWeight: 700, color, textTransform: 'uppercase',
-      letterSpacing: '.08em', marginBottom: 8, paddingBottom: 4, borderBottom: '1px solid var(--brd)',
-      display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-      minWidth: 0, overflow: 'hidden' }}>
+    <div style={{ fontSize: '0.77em', fontWeight: 700, color, textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8, paddingBottom: 4, borderBottom: '1px solid var(--brd)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', minWidth: 0, overflow: 'hidden' }}>
       <span style={{ whiteSpace: 'nowrap' }}>{icon} {label}</span>
-      {count != null && <span style={{ color: 'var(--mut)', fontWeight: 400, flexShrink: 0 }}>+{count}</span>}
+      {count != null && <span style={{ color: 'var(--mut)', fontWeight: 400, flexShrink: 0 }}>{count}</span>}
     </div>
   )
 
-  // Search results
   let searchHits = []
   if ((navSearch || '').trim().length > 1) {
     const q = (navSearch || '').trim().toLowerCase()
@@ -103,115 +134,110 @@ export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch
 
   return (
     <div style={{ width: '100%', minWidth: 0 }}>
-      {/* Stats — centred */}
-      <div style={{ display: 'flex', justifyContent: 'center', gap: 6, flexWrap: 'wrap', marginBottom: 14 }}>
-        {[
-          [tot, 'Total Entries', 'var(--cc)'],
-          [lk,  'Locked',        'var(--sl)'],
-          [pv,  'Provisional',   'var(--sp)'],
-          [op,  'Open',          'var(--so)'],
-          [fl,  '🚩 Flags',      'var(--cfl)', () => goTo('flags')],
-        ].map(([num, label, color, onClick], i) => (
-          <div key={i} className="dash-card" onClick={onClick}
-            style={{ cursor: onClick ? 'pointer' : 'default', minWidth: 100, textAlign: 'center' }}>
-            <div className="dash-num" style={{ color }}>{num}</div>
-            <div className="dash-label">{label}</div>
-          </div>
-        ))}
+      <div style={{ display: 'flex', justifyContent: 'center', gap: 6, flexWrap: 'wrap', alignItems: 'center', marginBottom: 14 }}>
+        <div className="dash-card" style={{ minWidth: 80, textAlign: 'center' }}>
+          <div className="dash-num" style={{ color: 'var(--so)' }}>{op}</div>
+          <div className="dash-label">Open</div>
+        </div>
+        <div className="dash-card" style={{ minWidth: 80, textAlign: 'center' }}>
+          <div className="dash-num" style={{ color: 'var(--sp)' }}>{pv}</div>
+          <div className="dash-label">Provisional</div>
+        </div>
+        <div className="dash-card" style={{ minWidth: 80, textAlign: 'center' }}>
+          <div className="dash-num" style={{ color: 'var(--sl)' }}>{lk}</div>
+          <div className="dash-label">Locked</div>
+        </div>
+        <div className="dash-card" style={{ minWidth: 80, textAlign: 'center' }}>
+          <div className="dash-num" style={{ color: 'var(--cc)' }}>= {tot}</div>
+          <div className="dash-label">Total</div>
+        </div>
+
+        <div style={{ width: 1, alignSelf: 'stretch', background: 'var(--brd)', margin: '0 8px', minHeight: 50 }} />
+
+        <div className="dash-card" style={{ minWidth: 100, textAlign: 'center' }}>
+          <div className="dash-num" style={{ color: 'var(--cc)' }}>{reviewCount}</div>
+          <div className="dash-label">🔍 Review Queue</div>
+        </div>
+        <div className="dash-card" onClick={() => goTo('flags')} style={{ cursor: 'pointer', minWidth: 100, textAlign: 'center' }}>
+          <div className="dash-num" style={{ color: 'var(--cfl)' }}>{fl}</div>
+          <div className="dash-label">🚩 Flags</div>
+        </div>
+        <div className="dash-card" onClick={() => goTo('questions')} style={{ cursor: 'pointer', minWidth: 100, textAlign: 'center' }}>
+          <div className="dash-num" style={{ color: 'var(--cq)' }}>{(data.questions || []).filter(q => q.status === 'open').length}</div>
+          <div className="dash-label">❓ Questions</div>
+        </div>
       </div>
 
-      {/* Search results — input is in the nav bar */}
       <div style={{ marginBottom: 14 }}>
         {searchHits.length > 0 && (
           <div style={{ marginTop: 6, background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 8, maxHeight: 220, overflowY: 'auto' }}>
             <div style={{ fontSize: '0.77em', color: 'var(--mut)', padding: '5px 10px', borderBottom: '1px solid var(--brd)' }}>
-              {searchHits.length} result{searchHits.length !== 1 ? 's' : ''} — click to go to tab
+              {searchHits.length} result{searchHits.length !== 1 ? 's' : ''} - click to open entry
             </div>
             {searchHits.slice(0, 30).map((h, i) => (
-              <div key={h.id || i} onClick={() => { goTo(h.cat); setNavSearch && setNavSearch('') }}
-                style={{ display: 'flex', justifyContent: 'space-between', padding: '5px 10px',
-                  borderBottom: '1px solid var(--brd)', cursor: 'pointer',
-                  background: i % 2 === 0 ? 'transparent' : 'rgba(255,255,255,.02)' }}
-                onMouseEnter={e => e.currentTarget.style.background = 'rgba(255,255,255,.06)'}
-                onMouseLeave={e => e.currentTarget.style.background = i % 2 === 0 ? 'transparent' : 'rgba(255,255,255,.02)'}>
+              <div
+                key={h.id || i}
+                onClick={() => { crossLink(h.cat, h.id); setNavSearch && setNavSearch('') }}
+                style={{ display: 'flex', justifyContent: 'space-between', padding: '5px 10px', borderBottom: '1px solid var(--brd)', cursor: 'pointer', background: i % 2 === 0 ? 'transparent' : 'rgba(255,255,255,.02)' }}
+                onMouseEnter={e => { e.currentTarget.style.background = 'rgba(255,255,255,.06)' }}
+                onMouseLeave={e => { e.currentTarget.style.background = i % 2 === 0 ? 'transparent' : 'rgba(255,255,255,.02)' }}
+              >
                 <span style={{ fontSize: '0.92em' }}>{h.name}</span>
                 <span style={{ fontSize: '0.77em', color: TAB_RAINBOW[h.cat] || 'var(--mut)' }}>{CATS[h.cat]?.i} {CATS[h.cat]?.l}</span>
               </div>
             ))}
-            {searchHits.length > 30 && (
-              <div style={{ fontSize: '0.77em', color: 'var(--mut)', padding: '5px 10px' }}>…and {searchHits.length - 30} more.</div>
-            )}
+            {searchHits.length > 30 && <div style={{ fontSize: '0.77em', color: 'var(--mut)', padding: '5px 10px' }}>...and {searchHits.length - 30} more.</div>}
           </div>
         )}
       </div>
 
-      {/* ── Main body: left nav + 3 panels ── */}
       <div style={{ display: 'flex', flexDirection: 'row', gap: 12, alignItems: 'flex-start', width: '100%', minWidth: 0 }}>
-
-        {/* Left nav — thin, rainbow list */}
-        <div style={{ flexShrink: 0, width: 160, minWidth: 0, borderRight: '2px solid var(--brd)', paddingRight: 10, marginRight: 2 }}>
+        <div style={{ flexShrink: 0, minWidth: 140, width: 'max-content', maxWidth: 220, borderRight: '2px solid var(--brd)', paddingRight: 10, marginRight: 2 }}>
           {TAB_LIST.map((k, i) => {
             const c = CATS[k]
             if (!c) return null
             const count = k === 'flags' ? fl : (data[k] || []).length
             const color = TAB_RAINBOW[k] || rc(i)
             return (
-              <div key={k}
-                style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                  padding: '4px 8px', marginBottom: 2, borderRadius: 4, cursor: 'pointer',
-                  borderLeft: `3px solid ${color}`,
-                  background: 'var(--card)', transition: '.12s' }}
+              <div
+                key={k}
+                style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, padding: '4px 8px', marginBottom: 2, borderRadius: 4, cursor: 'pointer', borderLeft: `3px solid ${color}`, background: 'var(--card)', transition: '.12s' }}
                 onClick={() => goTo(k)}
-                onMouseEnter={e => e.currentTarget.style.background = 'rgba(255,255,255,.06)'}
-                onMouseLeave={e => e.currentTarget.style.background = 'var(--card)'}>
-                <span style={{ fontSize: '0.85em', color: 'var(--tx)' }}>{c.i} {c.l}</span>
+                onMouseEnter={e => { e.currentTarget.style.background = 'rgba(255,255,255,.06)' }}
+                onMouseLeave={e => { e.currentTarget.style.background = 'var(--card)' }}
+              >
+                <span style={{ fontSize: '0.85em', color: 'var(--tx)', whiteSpace: 'nowrap' }}>{c.i} {c.l}</span>
                 <span style={{ fontSize: '0.92em', fontFamily: "'Cinzel',serif", color }}>{count}</span>
               </div>
             )
           })}
         </div>
 
-        {/* Recent */}
         <div style={{ flex: '0 1 auto', minWidth: 80, maxWidth: 'calc(33.33% - 8px)', overflow: 'hidden' }}>
           {panelHead('⏱', 'Recent', 'var(--tx)', null)}
           {recent.length === 0
             ? <div style={{ fontSize: '0.85em', color: 'var(--mut)', fontStyle: 'italic' }}>No recent entries</div>
-            : recent.slice(0, 14).map((r, i) => panelRow(
-                { ...r, detail: null },
-                i, TAB_RAINBOW[r.cat] || 'var(--cc)',
-                () => crossLink(r.cat, r.id)
-              ))
+            : recent.slice(0, 14).map((r, i) => panelRow({ ...r, detail: null }, i, TAB_RAINBOW[r.cat] || 'var(--cc)', () => crossLink(r.cat, r.id)))
           }
         </div>
 
-        {/* Questions */}
         <div style={{ flex: '1 1 0', minWidth: 140, overflow: 'hidden' }}>
-          {panelHead('?', 'Questions', 'var(--cq)', (data.questions || []).filter(q => q.status === 'open').length)}
-          {questions.length === 0
-            ? <div style={{ fontSize: '0.85em', color: 'var(--mut)', fontStyle: 'italic' }}>No open questions</div>
-            : questions.map((q, i) => panelRow(
-                { ...q, detail: q.detail },
-                i, 'var(--cq)',
-                () => goTo('questions')
-              ))
+          {panelHead('🔍', 'Review Queue', 'var(--cc)', reviewCount)}
+          {reviewItems.length === 0
+            ? <div style={{ fontSize: '0.85em', color: 'var(--mut)', fontStyle: 'italic' }}>Nothing to review</div>
+            : reviewItems.slice(0, 14).map((r, i) => panelRow({ ...r, detail: r.source === 'sticky' ? '📌 from sticky' : '📥 from session import' }, i, TAB_RAINBOW[r.cat] || 'var(--cc)', () => crossLink(r.cat, r.id)))
           }
         </div>
 
-        {/* Flags */}
         <div style={{ flex: '1 1 0', minWidth: 140, overflow: 'hidden' }}>
           {panelHead('🚩', 'Flags', 'var(--cfl)', fl)}
           {flags.length === 0
             ? <div style={{ fontSize: '0.85em', color: 'var(--mut)', fontStyle: 'italic' }}>No flags</div>
-            : flags.map((f, i) => panelRow(
-                { ...f, detail: f.detail },
-                i, 'var(--cfl)',
-                () => goTo('flags')
-              ))
+            : flags.map((f, i) => panelRow({ ...f, detail: f.detail }, i, 'var(--cfl)', () => crossLink('flags', f.id)))
           }
         </div>
       </div>
 
-      {/* Hidden file input for header image */}
       <input ref={imgRef} type="file" accept="image/*" style={{ display: 'none' }} onChange={handleHeaderImg} />
     </div>
   )

--- a/src/tabs/Flags.jsx
+++ b/src/tabs/Flags.jsx
@@ -1,140 +1,123 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Modal from '../components/common/Modal'
 import { uid } from '../constants'
+import { scrollAndFlashEntry } from '../components/common/entryNav'
 
 export default function Flags({ db }) {
   const flags = db.db.flags || []
   const [filter, setFilter] = useState('active')
   const [colCount, setColCount] = useState(() => parseInt(db.getSetting?.('fl_cols') || '2'))
-  function saveColCount(n) { setColCount(n); db.saveSetting?.('fl_cols', String(n)) } // 'active' | 'resolved' | 'all'
   const [dividers, setDividers] = useState(() => db.getSetting?.('fl_cols_div') !== 'off')
-  function toggleDividers() { const next = !dividers; setDividers(next); db.saveSetting?.('fl_cols_div', next ? 'on' : 'off') }
   const [modalOpen, setModalOpen] = useState(false)
   const [form, setForm] = useState({ name: '', priority: 'high', detail: '' })
   const [confirmId, setConfirmId] = useState(null)
-
   const [sortMode, setSortMode] = useState('newest')
+  const [autoOnly, setAutoOnly] = useState(false)
+
+  const autoCount = flags.filter(f => f.auto_imported === true).length
+  const priCol = { urgent: '#ff3355', high: '#ff7040', medium: '#ffcc00', low: '#7acc7a' }
+
+  useEffect(() => {
+    function onExpand(e) {
+      const targetId = e?.detail?.id
+      if (!targetId) return
+      const entry = flags.find(x => x.id === targetId)
+      if (!entry) return
+      setForm(entry)
+      setModalOpen(true)
+      window.setTimeout(() => scrollAndFlashEntry(targetId), 50)
+    }
+    window.addEventListener('gcomp_expand', onExpand)
+    return () => window.removeEventListener('gcomp_expand', onExpand)
+  }, [flags])
+
+  function saveColCount(n) { setColCount(n); db.saveSetting?.('fl_cols', String(n)) }
+  function toggleDividers() { const next = !dividers; setDividers(next); db.saveSetting?.('fl_cols_div', next ? 'on' : 'off') }
 
   const filtered = flags.filter(f => {
-    if (filter === 'active') return !f.resolved
-    if (filter === 'resolved') return !!f.resolved
-    return true
+    if (filter === 'active') return !f.resolved && (!autoOnly || f.auto_imported === true)
+    if (filter === 'resolved') return !!f.resolved && (!autoOnly || f.auto_imported === true)
+    return !autoOnly || f.auto_imported === true
   }).sort((a, b) => {
     if (sortMode === 'alpha') return (a.name || '').localeCompare(b.name || '')
     if (sortMode === 'oldest') return new Date(a.created || 0) - new Date(b.created || 0)
     if (sortMode === 'priority') {
       const order = { urgent: 0, high: 1, medium: 2, low: 3 }
-      return (order[a.priority||'']||4) - (order[b.priority||'']||4)
+      return (order[a.priority || ''] || 4) - (order[b.priority || ''] || 4)
     }
-    return new Date(b.created || 0) - new Date(a.created || 0) // newest first
+    return new Date(b.created || 0) - new Date(a.created || 0)
   })
 
-  const priCol = { urgent: '#ff3355', high: '#ff7040', medium: '#ffcc00', low: '#7acc7a' }
-
-  function addFlag() {
-    if (!form.name.trim()) return
+  function saveFlag() {
+    if (!form.name?.trim()) return
     const now = new Date().toISOString()
-    db.upsertEntry('flags', { id: uid(), ...form, resolved: false, created: now, updated_at: now })
+    const next = { id: form.id || uid(), resolved: false, created: form.created || now, updated_at: now, ...form }
+    db.upsertEntry('flags', next)
     setForm({ name: '', priority: 'high', detail: '' })
     setModalOpen(false)
   }
 
-  function resolve(f) {
-    db.upsertEntry('flags', { ...f, resolved: true, resolved_at: new Date().toISOString() })
-  }
-
-  function reopen(f) {
-    db.upsertEntry('flags', { ...f, resolved: false, resolved_at: null })
-  }
+  function resolve(f) { db.upsertEntry('flags', { ...f, resolved: true, resolved_at: new Date().toISOString() }) }
+  function reopen(f) { db.upsertEntry('flags', { ...f, resolved: false, resolved_at: null }) }
 
   return (
     <div>
       <div className="tbar">
         <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.15em', color: 'var(--cfl)' }}>🚩 Flags & Review</div>
-        <div style={{ display:'flex', gap:3 }}>
-          {[['XS',8],['S',5],['M',3],['L',2],['XL',1]].map(([l,n]) => (
-            <button key={l} onClick={() => saveColCount(n)}
-              style={{ fontSize: '0.69em', padding:'2px 7px', borderRadius:8,
-                background: colCount===n ? 'var(--cfl)' : 'none',
-                color: colCount===n ? '#000' : 'var(--dim)',
-                border: `1px solid ${colCount===n ? 'var(--cfl)' : 'var(--brd)'}`,
-                cursor:'pointer' }}>{l}</button>
+        <div style={{ display: 'flex', gap: 3 }}>
+          {[['XS', 8], ['S', 5], ['M', 3], ['L', 2], ['XL', 1]].map(([l, n]) => (
+            <button key={l} onClick={() => saveColCount(n)} style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, background: colCount === n ? 'var(--cfl)' : 'none', color: colCount === n ? '#000' : 'var(--dim)', border: `1px solid ${colCount === n ? 'var(--cfl)' : 'var(--brd)'}`, cursor: 'pointer' }}>{l}</button>
           ))}
-        
-        <button onClick={toggleDividers}
-          style={{ fontSize: '0.69em', padding:'2px 7px', borderRadius:8, marginLeft:8,
-            background: dividers ? 'rgba(255,255,255,.08)' : 'none',
-            color: dividers ? 'var(--tx)' : 'var(--mut)',
-            border:'1px solid var(--brd)', cursor:'pointer' }}>
-          {dividers ? '┃ on' : '┃ off'}
-        </button>
+          <button onClick={toggleDividers} style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, marginLeft: 8, background: dividers ? 'rgba(255,255,255,.08)' : 'none', color: dividers ? 'var(--tx)' : 'var(--mut)', border: '1px solid var(--brd)', cursor: 'pointer' }}>{dividers ? '┃ on' : '┃ off'}</button>
         </div>
-        <button className="btn btn-primary btn-sm" style={{ background: 'var(--cfl)', color: '#000' }} onClick={() => setModalOpen(true)}>+ Add Flag</button>
+        {autoCount > 0 && (
+          <button onClick={() => setAutoOnly(v => !v)} style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: `1px solid ${autoOnly ? '#ffcc00' : 'var(--brd)'}`, background: autoOnly ? '#ffcc0022' : 'none', color: autoOnly ? '#ffcc00' : 'var(--dim)', cursor: 'pointer' }}>
+            📥 Auto-imported ({autoCount})
+          </button>
+        )}
+        <button className="btn btn-primary btn-sm" style={{ background: 'var(--cfl)', color: '#000' }} onClick={() => { setForm({ name: '', priority: 'high', detail: '' }); setModalOpen(true) }}>+ Add Flag</button>
       </div>
 
-      {/* Filter */}
       <div className="tbar" style={{ paddingTop: 0 }}>
         <div className="filter-group">
-          {[['active','Active'],['resolved','Resolved'],['all','All']].map(([k,l]) => (
-            <button key={k} className={`fp ${filter===k?'active':''}`} style={{ color: 'var(--cfl)' }} onClick={() => setFilter(k)}>{l}</button>
-          ))}
+          {[['active', 'Active'], ['resolved', 'Resolved'], ['all', 'All']].map(([k, l]) => <button key={k} className={`fp ${filter === k ? 'active' : ''}`} style={{ color: 'var(--cfl)' }} onClick={() => setFilter(k)}>{l}</button>)}
         </div>
-        <span style={{ fontSize: '0.77em', color: 'var(--mut)', marginLeft: 8 }}>
-          {flags.filter(f => !f.resolved).length} active · {flags.filter(f => f.resolved).length} resolved
-        </span>
+        <span style={{ fontSize: '0.77em', color: 'var(--mut)', marginLeft: 8 }}>{flags.filter(f => !f.resolved).length} active · {flags.filter(f => f.resolved).length} resolved</span>
       </div>
 
-      {!filtered.length && (
-        <div className="empty">
-          <div className="empty-icon">🚩</div>
-          <p>{filter === 'resolved' ? 'No resolved flags.' : filter === 'active' ? 'No active flags!' : 'No flags.'}</p>
-        </div>
-      )}
+      {!filtered.length && <div className="empty"><div className="empty-icon">🚩</div><p>{filter === 'resolved' ? 'No resolved flags.' : filter === 'active' ? 'No active flags!' : 'No flags.'}</p></div>}
 
       <div style={{ columns: colCount, columnGap: 12, columnRule: dividers ? '1px solid var(--brd)' : 'none' }}>
-      {filtered.map(f => {
-        const pc = priCol[f.priority] || 'var(--dim)'
-        return (
-          <div key={f.id} className="flag-card" style={{ opacity: f.resolved ? 0.6 : 1, breakInside: 'avoid', marginBottom: 6 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <div style={{ fontSize: '0.92em', fontWeight: 600, color: f.resolved ? 'var(--dim)' : 'var(--tx)', textDecoration: f.resolved ? 'line-through' : 'none' }}>
-                {f.name}
+        {filtered.map(f => {
+          const pc = priCol[f.priority] || 'var(--dim)'
+          return (
+            <div key={f.id} id={`gcomp-entry-${f.id}`} className="flag-card" style={{ opacity: f.resolved ? 0.6 : 1, breakInside: 'avoid', marginBottom: 6 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div style={{ fontSize: '0.92em', fontWeight: 600, color: f.resolved ? 'var(--dim)' : 'var(--tx)', textDecoration: f.resolved ? 'line-through' : 'none' }}>{f.name}</div>
+                <span className="flag-pri" style={{ background: `${pc}22`, color: pc, border: `1px solid ${pc}44` }}>{f.priority || 'none'}</span>
               </div>
-              <span className="flag-pri" style={{ background: `${pc}22`, color: pc, border: `1px solid ${pc}44` }}>
-                {f.priority || 'none'}
-              </span>
+              {f.detail && <div style={{ fontSize: '0.85em', color: 'var(--dim)', marginTop: 3 }}>{f.detail}</div>}
+              {f.resolved && f.resolved_at && <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 3 }}>Resolved {new Date(f.resolved_at).toLocaleDateString()}</div>}
+              <div className="entry-actions" style={{ marginTop: 4 }}>
+                {!f.resolved
+                  ? <button className="btn btn-sm btn-outline" style={{ color: 'var(--sl)', borderColor: 'var(--sl)' }} onClick={() => resolve(f)}>✓ Resolve</button>
+                  : <button className="btn btn-sm btn-outline" style={{ color: 'var(--sp)', borderColor: 'var(--sp)' }} onClick={() => reopen(f)}>↩ Reopen</button>
+                }
+                <button className="btn btn-sm btn-outline" style={{ color: 'var(--cfl)', borderColor: 'var(--cfl)' }} onClick={() => { setForm(f); setModalOpen(true) }}>✎ Edit</button>
+                <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544' }} onClick={() => setConfirmId(f.id)}>✕ Delete</button>
+              </div>
             </div>
-            {f.detail && <div style={{ fontSize: '0.85em', color: 'var(--dim)', marginTop: 3 }}>{f.detail}</div>}
-            {f.resolved && f.resolved_at && (
-              <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 3 }}>Resolved {new Date(f.resolved_at).toLocaleDateString()}</div>
-            )}
-            <div className="entry-actions" style={{ marginTop: 4 }}>
-              {!f.resolved
-                ? <button className="btn btn-sm btn-outline" style={{ color: 'var(--sl)', borderColor: 'var(--sl)' }} onClick={() => resolve(f)}>✓ Resolve</button>
-                : <button className="btn btn-sm btn-outline" style={{ color: 'var(--sp)', borderColor: 'var(--sp)' }} onClick={() => reopen(f)}>↩ Reopen</button>
-              }
-              <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544' }} onClick={() => setConfirmId(f.id)}>✕ Delete</button>
-            </div>
-          </div>
-        )
-      })}
+          )
+        })}
       </div>
 
-      <Modal open={modalOpen} onClose={() => setModalOpen(false)} title="Add Flag" color="var(--cfl)">
-        <div className="field"><label>Description *</label>
-          <input value={form.name} onChange={e => setForm(p => ({...p, name: e.target.value}))} placeholder="What needs attention?" />
-        </div>
-        <div className="field"><label>Priority</label>
-          <select value={form.priority} onChange={e => setForm(p => ({...p, priority: e.target.value}))}>
-            {['urgent','high','medium','low'].map(p => <option key={p} value={p}>{p}</option>)}
-          </select>
-        </div>
-        <div className="field"><label>Detail</label>
-          <textarea value={form.detail} onChange={e => setForm(p => ({...p, detail: e.target.value}))} placeholder="Optional detail…" />
-        </div>
+      <Modal open={modalOpen} onClose={() => setModalOpen(false)} title={form.id ? 'Edit Flag' : 'Add Flag'} color="var(--cfl)">
+        <div className="field"><label>Description *</label><input value={form.name || ''} onChange={e => setForm(p => ({ ...p, name: e.target.value }))} placeholder="What needs attention?" /></div>
+        <div className="field"><label>Priority</label><select value={form.priority || 'high'} onChange={e => setForm(p => ({ ...p, priority: e.target.value }))}>{['urgent', 'high', 'medium', 'low'].map(p => <option key={p} value={p}>{p}</option>)}</select></div>
+        <div className="field"><label>Detail</label><textarea value={form.detail || ''} onChange={e => setForm(p => ({ ...p, detail: e.target.value }))} placeholder="Optional detail..." /></div>
         <div className="modal-actions">
           <button className="btn btn-outline" onClick={() => setModalOpen(false)}>Cancel</button>
-          <button className="btn btn-primary" style={{ background: 'var(--cfl)', color: '#000' }} onClick={addFlag}>Add Flag</button>
+          <button className="btn btn-primary" style={{ background: 'var(--cfl)', color: '#000' }} onClick={saveFlag}>{form.id ? 'Save Flag' : 'Add Flag'}</button>
         </div>
       </Modal>
 

--- a/src/tabs/Glossary.jsx
+++ b/src/tabs/Glossary.jsx
@@ -1,53 +1,53 @@
-const SIZE_COLS_GLOSS = { XS: 3, S: 2, M: 1, L: 1, XL: 1 }
-
-import { useState, useMemo, useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import FilterPopup from '../components/common/FilterPopup'
+import AlphabetJumpBar from '../components/common/AlphabetJumpBar'
+import { scrollAndFlashEntry } from '../components/common/entryNav'
 
-// Categories that are glossary-relevant by default
 const GLOSSARY_CATS = ['Languages', 'Lore', 'Cosmology', 'Power System', 'Cultures', 'Religions', 'Factions', 'Geography']
-
-const ALPHA = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ#'.split('')
 
 export default function Glossary({ db, goTo, goToWiki, navSearch }) {
   const [search, setSearch] = useState(navSearch || '')
-  const [colSize, setColSize] = useState(() => {
-    try { return localStorage.getItem('colsize_glossary') || 'M' } catch { return 'M' }
-  })
-  const cols = SIZE_COLS_GLOSS[colSize] || 1
-  function changeColSize(sz) { setColSize(sz); try { localStorage.setItem('colsize_glossary', sz) } catch {} }
-  const [jumpLetter, setJumpLetter] = useState(null)
+  const [filterValues, setFilterValues] = useState({})
+  const [autoOnly, setAutoOnly] = useState(false)
 
   useEffect(() => { setSearch(navSearch || '') }, [navSearch])
-  const [filterValues, setFilterValues] = useState({})
 
   const articles = db.db.wiki || []
-
-  // Glossary = Wiki entries in glossary-relevant categories OR flagged as glossary
-  const glossaryEntries = useMemo(() => {
-    return articles
+  const glossaryEntries = useMemo(() => (
+    articles
       .filter(a => GLOSSARY_CATS.includes(a.category) || a.is_glossary)
       .sort((a, b) => (a.title || '').localeCompare(b.title || ''))
-  }, [articles])
+  ), [articles])
 
+  const autoCount = glossaryEntries.filter(a => a.auto_imported === true).length
   const availableCats = useMemo(() => {
     const cats = new Set(glossaryEntries.map(a => a.category).filter(Boolean))
-    return ['all', ...GLOSSARY_CATS.filter(c => cats.has(c))]
+    return GLOSSARY_CATS.filter(c => cats.has(c))
+  }, [glossaryEntries])
+
+  useEffect(() => {
+    function onExpand(e) {
+      const targetId = e?.detail?.id
+      if (!targetId) return
+      const entry = glossaryEntries.find(x => x.id === targetId)
+      if (!entry) return
+      window.setTimeout(() => scrollAndFlashEntry(targetId), 50)
+    }
+    window.addEventListener('gcomp_expand', onExpand)
+    return () => window.removeEventListener('gcomp_expand', onExpand)
   }, [glossaryEntries])
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase()
-    const selectedCats = filterValues['category'] || []
+    const selectedCats = filterValues.category || []
     return glossaryEntries.filter(a => {
       const mc = selectedCats.length === 0 || selectedCats.includes(a.category)
       const mq = !q || (a.title || '').toLowerCase().includes(q) || (a.summary || '').toLowerCase().includes(q)
-      const ml = !jumpLetter || (jumpLetter === '#'
-        ? !/^[a-z]/i.test(a.title || '')
-        : (a.title || '').toUpperCase().startsWith(jumpLetter))
-      return mc && mq && ml
+      const ma = !autoOnly || a.auto_imported === true
+      return mc && mq && ma
     })
-  }, [glossaryEntries, search, filterValues, jumpLetter])
+  }, [glossaryEntries, search, filterValues, autoOnly])
 
-  // Group by first letter for dictionary display
   const grouped = useMemo(() => {
     const g = {}
     filtered.forEach(a => {
@@ -62,72 +62,31 @@ export default function Glossary({ db, goTo, goToWiki, navSearch }) {
 
   return (
     <div>
-      {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-        marginBottom: 12, flexWrap: 'wrap', gap: 8 }}>
-        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.15em', color: '#ff6b6b' }}>
-          📚 Glossary
-        </div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12, flexWrap: 'wrap', gap: 8 }}>
+        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.15em', color: '#ff6b6b' }}>📚 Glossary</div>
         <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
-          <span style={{ fontSize: '0.77em', color: 'var(--mut)' }}>
-            {filtered.length} term{filtered.length !== 1 ? 's' : ''}
-          </span>
-          <button onClick={() => goTo('wiki')}
-            style={{ fontSize: '0.77em', padding: '3px 10px', borderRadius: 8, background: 'none',
-              border: '1px solid var(--brd)', color: 'var(--dim)', cursor: 'pointer' }}>
-            → Full Wiki
-          </button>
+          <span style={{ fontSize: '0.77em', color: 'var(--mut)' }}>{filtered.length} term{filtered.length !== 1 ? 's' : ''}</span>
+          <button onClick={() => goTo('wiki')} style={{ fontSize: '0.77em', padding: '3px 10px', borderRadius: 8, background: 'none', border: '1px solid var(--brd)', color: 'var(--dim)', cursor: 'pointer' }}>→ Full Wiki</button>
         </div>
       </div>
 
-      {/* Search + filter */}
       <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 10, alignItems: 'center' }}>
-        <input className="sx" placeholder="Search terms…" value={search}
-          onChange={e => { setSearch(e.target.value); setJumpLetter(null) }}
-          style={{ flex: 1, minWidth: 180 }} />
-        <FilterPopup
-          color="#ff6b6b"
-          filters={[{
-            key: 'category',
-            label: 'Category',
-            options: availableCats.filter(c => c !== 'all').map(c => ({ value: c, label: c }))
-          }]}
-          values={filterValues}
-          onChange={(key, vals) => setFilterValues(prev => ({ ...prev, [key]: vals }))}
-        />
+        <input className="sx" placeholder="Search terms..." value={search} onChange={e => setSearch(e.target.value)} style={{ flex: 1, minWidth: 180 }} />
+        {autoCount > 0 && (
+          <button onClick={() => setAutoOnly(v => !v)} style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: `1px solid ${autoOnly ? '#ffcc00' : 'var(--brd)'}`, background: autoOnly ? '#ffcc0022' : 'none', color: autoOnly ? '#ffcc00' : 'var(--dim)', cursor: 'pointer' }}>
+            📥 Auto-imported ({autoCount})
+          </button>
+        )}
+        <FilterPopup color="#ff6b6b" filters={[{ key: 'category', label: 'Category', options: availableCats.map(c => ({ value: c, label: c })) }]} values={filterValues} onChange={(key, vals) => setFilterValues(prev => ({ ...prev, [key]: vals }))} />
       </div>
 
-      {/* Alpha jump bar */}
-      <div style={{ display: 'flex', gap: 2, flexWrap: 'wrap', marginBottom: 12 }}>
-        {ALPHA.map(l => {
-          const hasEntries = grouped[l]?.length > 0
-          return (
-            <button key={l} onClick={() => setJumpLetter(jumpLetter === l ? null : l)}
-              disabled={!hasEntries}
-              style={{ fontSize: '0.77em', padding: '2px 6px', borderRadius: 4, cursor: hasEntries ? 'pointer' : 'default',
-                fontFamily: "'Cinzel',serif", fontWeight: 600,
-                background: jumpLetter === l ? '#ff6b6b' : 'none',
-                color: jumpLetter === l ? '#000' : hasEntries ? '#ff6b6b' : 'var(--brd)',
-                border: `1px solid ${jumpLetter === l ? '#ff6b6b' : hasEntries ? 'rgba(201,102,255,.3)' : 'transparent'}` }}>
-              {l}
-            </button>
-          )
-        })}
-      </div>
+      <AlphabetJumpBar entries={filtered} getName={e => e.term || e.title} onJump={target => scrollAndFlashEntry(target.id)} color="#ff6b6b" />
 
-      {/* No entries state */}
       {articles.length === 0 && (
         <div className="empty">
           <div className="empty-icon">📚</div>
           <p>No Wiki entries yet.</p>
-          <p style={{ fontSize: '0.85em', color: 'var(--mut)', marginTop: 4 }}>
-            The Glossary pulls from Wiki entries in the Lore, Languages, Cosmology,
-            Power System, Cultures, Religions, and Factions categories.
-          </p>
-          <button className="btn btn-primary" style={{ background: '#ff6b6b', marginTop: 8 }}
-            onClick={() => goTo('wiki')}>
-            → Go to Wiki
-          </button>
+          <button className="btn btn-primary" style={{ background: '#ff6b6b', marginTop: 8 }} onClick={() => goTo('wiki')}>→ Go to Wiki</button>
         </div>
       )}
 
@@ -138,64 +97,30 @@ export default function Glossary({ db, goTo, goToWiki, navSearch }) {
         </div>
       )}
 
-      {/* Dictionary display — grouped by letter */}
       {letters.map(letter => (
         <div key={letter} style={{ marginBottom: 20 }}>
-          {/* Letter header */}
-          <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.54em', fontWeight: 700,
-            color: '#ff6b6b', borderBottom: '1px solid rgba(201,102,255,.2)',
-            paddingBottom: 4, marginBottom: 8, letterSpacing: '.1em' }}>
-            {letter}
-          </div>
-
+          <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.54em', fontWeight: 700, color: '#ff6b6b', borderBottom: '1px solid rgba(201,102,255,.2)', paddingBottom: 4, marginBottom: 8, letterSpacing: '.1em' }}>{letter}</div>
           {grouped[letter].map(entry => (
-            <div key={entry.id}
-              style={{ display: 'flex', gap: 12, padding: '8px 0',
-                borderBottom: '1px solid rgba(255,255,255,.04)',
-                cursor: 'pointer' }}
-              onClick={() => goToWiki ? goToWiki(entry) : goTo('wiki')}>
+            <div key={entry.id} id={`gcomp-entry-${entry.id}`} style={{ display: 'flex', gap: 12, padding: '8px 0', borderBottom: '1px solid rgba(255,255,255,.04)', cursor: 'pointer' }} onClick={() => goToWiki ? goToWiki(entry) : goTo('wiki')}>
               <div style={{ flex: 1 }}>
                 <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
-                  <span style={{ fontFamily: "'Cinzel',serif", fontSize: '1em',
-                    fontWeight: 700, color: 'var(--tx)' }}>{entry.title}</span>
-                  <span style={{ fontSize: '0.69em', color: '#ff6b6b', textTransform: 'uppercase',
-                    letterSpacing: '.06em', opacity: 0.7 }}>{entry.category}</span>
+                  <span style={{ fontFamily: "'Cinzel',serif", fontSize: '1em', fontWeight: 700, color: 'var(--tx)' }}>{entry.title}</span>
+                  <span style={{ fontSize: '0.69em', color: '#ff6b6b', textTransform: 'uppercase', letterSpacing: '.06em', opacity: 0.7 }}>{entry.category}</span>
+                  {entry.auto_imported && <span style={{ fontSize: '0.69em', color: '#ffcc00' }}>📥</span>}
                 </div>
-                {entry.summary && (
-                  <div style={{ fontSize: '0.92em', color: 'var(--dim)', marginTop: 3, lineHeight: 1.5 }}>
-                    {entry.summary}
-                  </div>
-                )}
-                {/* Show first text block content if short enough */}
+                {entry.summary && <div style={{ fontSize: '0.92em', color: 'var(--dim)', marginTop: 3, lineHeight: 1.5 }}>{entry.summary}</div>}
                 {!entry.summary && entry.blocks?.length > 0 && (() => {
                   const firstText = entry.blocks.find(b => b.type === 'text')
                   if (!firstText?.content) return null
                   const preview = firstText.content.slice(0, 160)
-                  return (
-                    <div style={{ fontSize: '0.85em', color: 'var(--mut)', marginTop: 3,
-                      lineHeight: 1.5, fontStyle: 'italic' }}>
-                      {preview}{firstText.content.length > 160 ? '…' : ''}
-                    </div>
-                  )
+                  return <div style={{ fontSize: '0.85em', color: 'var(--mut)', marginTop: 3, lineHeight: 1.5, fontStyle: 'italic' }}>{preview}{firstText.content.length > 160 ? '…' : ''}</div>
                 })()}
               </div>
-              <div style={{ flexShrink: 0, fontSize: '0.77em', color: 'var(--mut)', paddingTop: 3 }}>
-                {(entry.blocks?.length || 0) > 0 && `${entry.blocks.length} block${entry.blocks.length !== 1 ? 's' : ''}`}
-              </div>
+              <div style={{ flexShrink: 0, fontSize: '0.77em', color: 'var(--mut)', paddingTop: 3 }}>{(entry.blocks?.length || 0) > 0 && `${entry.blocks.length} block${entry.blocks.length !== 1 ? 's' : ''}`}</div>
             </div>
           ))}
         </div>
       ))}
-
-      {/* Footer note */}
-      {articles.length > 0 && (
-        <div style={{ marginTop: 16, padding: '8px 12px', background: 'var(--card)',
-          border: '1px solid var(--brd)', borderRadius: 6, fontSize: '0.77em', color: 'var(--mut)',
-          lineHeight: 1.6 }}>
-          💡 Glossary shows Wiki entries in Lore, Languages, Cosmology, Power System, Cultures, Religions, and Factions categories.
-          To add a term, create a Wiki entry in one of those categories. Full entries open in the Wiki tab.
-        </div>
-      )}
     </div>
   )
 }

--- a/src/tabs/Inventory.jsx
+++ b/src/tabs/Inventory.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useRef } from 'react'
+import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import OutfitSnapshot from './OutfitSnapshot'
 import Modal from '../components/common/Modal'
 import EntryForm from '../components/common/EntryForm'
@@ -6,6 +6,7 @@ import Lightbox from '../components/common/Lightbox'
 import ImagePicker from '../components/common/ImagePicker'
 import { uploadImage } from '../hooks/useImageUpload'
 import { highlight, uid, SL } from '../constants'
+import { scrollAndFlashEntry } from '../components/common/entryNav'
 
 // ── Category config ───────────────────────────────────────────────
 const CATEGORIES = [
@@ -378,6 +379,22 @@ export default function Inventory({ db }) {
   const [dragOverIdx, setDragOverIdx] = useState(null)
   const [showColPicker, setShowColPicker] = useState(false)
 
+  useEffect(() => {
+    function onExpand(e) {
+      const targetId = e?.detail?.id
+      if (!targetId) return
+      const entry = allEntries.find(x => x.id === targetId)
+      if (!entry) return
+      const holderChar = chars.find(c => c.id === (entry.character || entry.holder))
+      const stableIdx = chars.indexOf(holderChar)
+      const bubbleColor = holderChar?.bubble_color || holderChar?.clothing_color || DEFAULT_COLORS[Math.max(0, stableIdx) % DEFAULT_COLORS.length]
+      setViewPopup({ entry, bubbleColor })
+      window.setTimeout(() => scrollAndFlashEntry(targetId), 50)
+    }
+    window.addEventListener('gcomp_expand', onExpand)
+    return () => window.removeEventListener('gcomp_expand', onExpand)
+  }, [allEntries, chars])
+
   function saveColumns(n) {
     setColumns(n)
     db.saveSetting?.('inv_columns', String(n))
@@ -635,7 +652,7 @@ export default function Inventory({ db }) {
             const bubbleColor = holderChar?.bubble_color || holderChar?.clothing_color || DEFAULT_COLORS[Math.max(0,stableIdx) % DEFAULT_COLORS.length]
             const tileColor = e.entry_color || bubbleColor
             return (
-              <div key={e.id} className="entry-card"
+              <div key={e.id} id={`gcomp-entry-${e.id}`} className="entry-card"
                 style={{ '--card-color': tileColor, borderTop: `2px solid ${tileColor}` }}
                 onClick={() => setViewPopup({ entry: e, bubbleColor })}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>

--- a/src/tabs/Items.jsx
+++ b/src/tabs/Items.jsx
@@ -1,10 +1,11 @@
-import { useState, useRef, useCallback } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Modal from '../components/common/Modal'
 import EntryForm from '../components/common/EntryForm'
 import { highlight, uid, SL } from '../constants'
 import Lightbox from '../components/common/Lightbox'
 import ImagePicker from '../components/common/ImagePicker'
 import { uploadImage } from '../hooks/useImageUpload'
+import { scrollAndFlashEntry } from '../components/common/entryNav'
 
 const ITEM_FIELDS = [
   { k: 'name',         l: 'Name',           t: 'text', r: true },
@@ -255,6 +256,21 @@ export default function Items({ db }) {
   const [pickerForItem, setPickerForItem] = useState(null)
   const [dragIdx, setDragIdx] = useState(null)
   const [dragOverIdx, setDragOverIdx] = useState(null)
+  const [autoOnly, setAutoOnly] = useState(false)
+  const autoCount = items.filter(i => i.auto_imported === true).length
+
+  useEffect(() => {
+    function onExpand(e) {
+      const targetId = e?.detail?.id
+      if (!targetId) return
+      const entry = items.find(x => x.id === targetId)
+      if (!entry) return
+      setViewPopup(entry)
+      window.setTimeout(() => scrollAndFlashEntry(targetId), 50)
+    }
+    window.addEventListener('gcomp_expand', onExpand)
+    return () => window.removeEventListener('gcomp_expand', onExpand)
+  }, [items])
 
   function holderName(id) {
     if (!id) return 'Unassigned'
@@ -312,7 +328,7 @@ export default function Items({ db }) {
     setDragIdx(null); setDragOverIdx(null)
   }
 
-  const filtered = items.filter(e => !search || JSON.stringify(e).toLowerCase().includes(search.toLowerCase()))
+  const filtered = items.filter(e => (!search || JSON.stringify(e).toLowerCase().includes(search.toLowerCase())) && (!autoOnly || e.auto_imported === true))
 
   // Group by holder
   const grouped = {}
@@ -352,6 +368,7 @@ export default function Items({ db }) {
           <button className={`btn btn-sm btn-outline ${viewMode === 'list' ? 'active' : ''}`}
             style={{ fontSize: '0.77em' }} onClick={() => setViewMode('list')}>List</button>
         </div>
+        {autoCount > 0 && <button onClick={() => setAutoOnly(v => !v)} style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: `1px solid ${autoOnly ? '#ffcc00' : 'var(--brd)'}`, background: autoOnly ? '#ffcc0022' : 'none', color: autoOnly ? '#ffcc00' : 'var(--dim)', cursor: 'pointer' }}>📥 Auto-imported ({autoCount})</button>}
         <button className="btn btn-primary btn-sm" style={{ background: 'var(--ci)' }}
           onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add</button>
       </div>
@@ -393,7 +410,7 @@ export default function Items({ db }) {
           {filtered.map((e, i) => {
             const isOpen = expanded === e.id
             return (
-              <div key={e.id} className="entry-card"
+              <div key={e.id} id={`gcomp-entry-${e.id}`} className="entry-card"
                 style={{ '--card-color': 'var(--ci)', background: i % 2 === 1 ? 'rgba(255,255,255,.01)' : undefined }}
                 onClick={() => setExpanded(isOpen ? null : e.id)}>
                 <div style={{ display: 'flex', justifyContent: 'space-between' }}>

--- a/src/tabs/Locations.jsx
+++ b/src/tabs/Locations.jsx
@@ -1,21 +1,25 @@
-import { useState, useRef, useCallback } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Modal from '../components/common/Modal'
 import EntryForm from '../components/common/EntryForm'
-import { uid } from '../constants'
+import AlphabetJumpBar from '../components/common/AlphabetJumpBar'
+import { scrollAndFlashEntry } from '../components/common/entryNav'
 
-const TAB_COLOR = '#ffb700' // Amber
+const TAB_COLOR = '#ffb700'
 
 const LOC_FIELDS = [
-  { k: 'name',        l: 'Name',             t: 'text', r: true },
-  { k: 'loc_type',    l: 'Type',             t: 'sel', o: ['','World','Continent','Country','City/Town','Building','Room/Area','Landmark','Island','Body of Water','Portal','Other'] },
-  { k: 'parent_id',   l: 'Inside / Part of', t: 'locsel' },
-  { k: 'description', l: 'Description',      t: 'ta' },
+  { k: 'name', l: 'Name', t: 'text', r: true },
+  { k: 'loc_type', l: 'Type', t: 'sel', o: ['', 'World', 'Continent', 'Country', 'City/Town', 'Building', 'Room/Area', 'Landmark', 'Island', 'Body of Water', 'Portal', 'Other'] },
+  { k: 'parent_id', l: 'Inside / Part of', t: 'locsel' },
+  { k: 'description', l: 'Description', t: 'ta' },
 ]
 
 function locPath(id, locations) {
   const parts = []
   let cur = locations.find(l => l.id === id)
-  while (cur) { parts.unshift(cur.name); cur = cur.parent_id ? locations.find(l => l.id === cur.parent_id) : null }
+  while (cur) {
+    parts.unshift(cur.name)
+    cur = cur.parent_id ? locations.find(l => l.id === cur.parent_id) : null
+  }
   return parts.join(' → ')
 }
 
@@ -24,13 +28,11 @@ function LocNode({ loc, locations, expanded, onToggle, onEdit, onDelete, onAddCh
   const isOpen = expanded.has(loc.id)
   return (
     <div style={{ marginBottom: 2 }}>
-      <div className="loc-node" onClick={() => onToggle(loc.id)}>
-        {kids.length > 0
-          ? <span style={{ fontSize: '0.69em', color: TAB_COLOR, transition: '.2s', display: 'inline-block', transform: isOpen ? 'rotate(90deg)' : 'none' }}>►</span>
-          : <span style={{ width: 12 }} />
-        }
+      <div id={`gcomp-entry-${loc.id}`} className="loc-node" onClick={() => onToggle(loc.id)}>
+        {kids.length > 0 ? <span style={{ fontSize: '0.69em', color: TAB_COLOR, transition: '.2s', display: 'inline-block', transform: isOpen ? 'rotate(90deg)' : 'none' }}>►</span> : <span style={{ width: 12 }} />}
         <span style={{ fontSize: '0.92em', fontWeight: 600 }}>{loc.name}</span>
         {loc.status && <span className={`badge badge-${loc.status}`} style={{ marginLeft: 4 }}>{loc.status}</span>}
+        {loc.auto_imported && <span style={{ marginLeft: 6, fontSize: '0.69em', color: '#ffcc00' }}>📥</span>}
         <span style={{ fontSize: '0.69em', color: 'var(--mut)', marginLeft: 'auto' }}>{loc.loc_type || ''}</span>
       </div>
       {isOpen && (
@@ -46,26 +48,16 @@ function LocNode({ loc, locations, expanded, onToggle, onEdit, onDelete, onAddCh
       )}
       {isOpen && kids.length > 0 && (
         <div className="loc-children">
-          {kids.map(k => (
-            <LocNode key={k.id} loc={k} locations={locations} expanded={expanded}
-              onToggle={onToggle} onEdit={onEdit} onDelete={onDelete} onAddChild={onAddChild} />
-          ))}
+          {kids.map(k => <LocNode key={k.id} loc={k} locations={locations} expanded={expanded} onToggle={onToggle} onEdit={onEdit} onDelete={onDelete} onAddChild={onAddChild} />)}
         </div>
       )}
     </div>
   )
 }
 
-// ── Flat table with drag-resizable columns ────────────────────────
 function FlatTable({ locations, onEdit, onDelete, onAddChild, navSearch }) {
   const search = (navSearch || '').toLowerCase()
-  const visible = locations.filter(l =>
-    !search || l.name?.toLowerCase().includes(search) ||
-    l.loc_type?.toLowerCase().includes(search) ||
-    l.description?.toLowerCase().includes(search)
-  )
-
-  // Column widths — draggable
+  const visible = locations.filter(l => !search || l.name?.toLowerCase().includes(search) || l.loc_type?.toLowerCase().includes(search) || l.description?.toLowerCase().includes(search))
   const [colWidths, setColWidths] = useState([220, 140, 200, 160, 80])
   const dragging = useRef(null)
 
@@ -91,42 +83,26 @@ function FlatTable({ locations, onEdit, onDelete, onAddChild, navSearch }) {
   }
 
   const COLS = ['Name', 'Type', 'Path', 'Description', 'Actions']
-  const tdStyle = (i) => ({
-    padding: '5px 8px', borderBottom: '1px solid var(--brd)',
-    fontSize: '0.85em', color: 'var(--tx)', verticalAlign: 'top',
-    maxWidth: colWidths[i], overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-  })
+  const tdStyle = i => ({ padding: '5px 8px', borderBottom: '1px solid var(--brd)', fontSize: '0.85em', color: 'var(--tx)', verticalAlign: 'top', maxWidth: colWidths[i], overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' })
 
   return (
     <div style={{ overflowX: 'auto' }}>
-      <table style={{ borderCollapse: 'collapse', tableLayout: 'fixed', minWidth: colWidths.reduce((a,b) => a+b, 0) }}>
-        <colgroup>
-          {colWidths.map((w, i) => <col key={i} style={{ width: w }} />)}
-        </colgroup>
+      <table style={{ borderCollapse: 'collapse', tableLayout: 'fixed', minWidth: colWidths.reduce((a, b) => a + b, 0) }}>
+        <colgroup>{colWidths.map((w, i) => <col key={i} style={{ width: w }} />)}</colgroup>
         <thead>
           <tr style={{ background: 'var(--sf)', borderBottom: `2px solid ${TAB_COLOR}` }}>
             {COLS.map((col, i) => (
-              <th key={col} style={{ padding: '6px 8px', textAlign: 'left', fontSize: '0.77em',
-                fontWeight: 700, color: TAB_COLOR, textTransform: 'uppercase', letterSpacing: '.05em',
-                position: 'relative', userSelect: 'none', width: colWidths[i] }}>
+              <th key={col} style={{ padding: '6px 8px', textAlign: 'left', fontSize: '0.77em', fontWeight: 700, color: TAB_COLOR, textTransform: 'uppercase', letterSpacing: '.05em', position: 'relative', userSelect: 'none', width: colWidths[i] }}>
                 {col}
-                {i < COLS.length - 1 && (
-                  <div
-                    onMouseDown={e => onMouseDown(e, i)}
-                    style={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 6,
-                      cursor: 'col-resize', background: 'transparent', zIndex: 1 }}
-                  />
-                )}
+                {i < COLS.length - 1 && <div onMouseDown={e => onMouseDown(e, i)} style={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 6, cursor: 'col-resize', background: 'transparent', zIndex: 1 }} />}
               </th>
             ))}
           </tr>
         </thead>
         <tbody>
-          {visible.length === 0 && (
-            <tr><td colSpan={5} style={{ padding: 20, textAlign: 'center', color: 'var(--mut)', fontStyle: 'italic' }}>No locations found.</td></tr>
-          )}
+          {visible.length === 0 && <tr><td colSpan={5} style={{ padding: 20, textAlign: 'center', color: 'var(--mut)', fontStyle: 'italic' }}>No locations found.</td></tr>}
           {visible.map((l, idx) => (
-            <tr key={l.id} style={{ background: idx % 2 === 0 ? 'var(--card)' : 'transparent' }}>
+            <tr key={l.id} id={`gcomp-entry-${l.id}`} style={{ background: idx % 2 === 0 ? 'var(--card)' : 'transparent' }}>
               <td style={tdStyle(0)}><span style={{ fontWeight: 600 }}>{l.name}</span></td>
               <td style={tdStyle(1)}><span style={{ color: TAB_COLOR, fontSize: '0.85em' }}>{l.loc_type || '—'}</span></td>
               <td style={{ ...tdStyle(2), color: 'var(--dim)' }}>{locPath(l.id, locations) || '—'}</td>
@@ -146,17 +122,32 @@ function FlatTable({ locations, onEdit, onDelete, onAddChild, navSearch }) {
 
 export default function Locations({ db, navSearch }) {
   const locations = db.db.locations || []
-  const [view, setView] = useState('tree') // 'tree' | 'table'
+  const [view, setView] = useState('tree')
   const [expanded, setExpanded] = useState(new Set())
   const [modalOpen, setModalOpen] = useState(false)
   const [editing, setEditing] = useState(null)
   const [confirmId, setConfirmId] = useState(null)
+  const [autoOnly, setAutoOnly] = useState(false)
 
   const search = (navSearch || '').toLowerCase()
+  const autoCount = locations.filter(l => l.auto_imported === true).length
 
-  function toggle(id) {
-    setExpanded(prev => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n })
-  }
+  useEffect(() => {
+    function onExpand(e) {
+      const targetId = e?.detail?.id
+      if (!targetId) return
+      const entry = locations.find(x => x.id === targetId)
+      if (!entry) return
+      setEditing(entry)
+      setModalOpen(true)
+      setExpanded(prev => new Set(prev).add(targetId))
+      window.setTimeout(() => scrollAndFlashEntry(targetId), 50)
+    }
+    window.addEventListener('gcomp_expand', onExpand)
+    return () => window.removeEventListener('gcomp_expand', onExpand)
+  }, [locations])
+
+  function toggle(id) { setExpanded(prev => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n }) }
   function openAdd(parentId) { setEditing(parentId ? { parent_id: parentId } : {}); setModalOpen(true) }
   function handleSave(entry) { db.upsertEntry('locations', entry); setModalOpen(false); setEditing(null) }
   function handleDelete(id) {
@@ -166,16 +157,9 @@ export default function Locations({ db, navSearch }) {
   }
 
   const roots = locations.filter(l => !l.parent_id)
-  const filtered = search
-    ? locations.filter(l => l.name?.toLowerCase().includes(search) || l.loc_type?.toLowerCase().includes(search))
-    : roots
+  const filtered = (search ? locations.filter(l => l.name?.toLowerCase().includes(search) || l.loc_type?.toLowerCase().includes(search)) : roots).filter(l => !autoOnly || l.auto_imported === true)
 
-  const btnStyle = (active) => ({
-    fontSize: '0.77em', padding: '3px 10px', borderRadius: 6, cursor: 'pointer',
-    border: `1px solid ${active ? TAB_COLOR : 'var(--brd)'}`,
-    background: active ? TAB_COLOR + '22' : 'none',
-    color: active ? TAB_COLOR : 'var(--dim)',
-  })
+  const btnStyle = active => ({ fontSize: '0.77em', padding: '3px 10px', borderRadius: 6, cursor: 'pointer', border: `1px solid ${active ? TAB_COLOR : 'var(--brd)'}`, background: active ? `${TAB_COLOR}22` : 'none', color: active ? TAB_COLOR : 'var(--dim)' })
 
   return (
     <div>
@@ -185,54 +169,31 @@ export default function Locations({ db, navSearch }) {
           <button style={btnStyle(view === 'tree')} onClick={() => setView('tree')}>🌳 Tree</button>
           <button style={btnStyle(view === 'table')} onClick={() => setView('table')}>☰ Table</button>
         </div>
+        {autoCount > 0 && <button onClick={() => setAutoOnly(v => !v)} style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: `1px solid ${autoOnly ? '#ffcc00' : 'var(--brd)'}`, background: autoOnly ? '#ffcc0022' : 'none', color: autoOnly ? '#ffcc00' : 'var(--dim)', cursor: 'pointer' }}>📥 Auto-imported ({autoCount})</button>}
         <button className="btn btn-primary btn-sm" style={{ background: TAB_COLOR, color: '#000' }} onClick={() => openAdd()}>+ Add</button>
       </div>
 
-      {!locations.length && (
-        <div className="empty"><div className="empty-icon">🗺</div><p>No locations yet.</p></div>
-      )}
+      <AlphabetJumpBar entries={locations.filter(l => !autoOnly || l.auto_imported === true)} getName={e => e.name} onJump={target => scrollAndFlashEntry(target.id)} color={TAB_COLOR} />
+
+      {!locations.length && <div className="empty"><div className="empty-icon">🗺</div><p>No locations yet.</p></div>}
 
       {view === 'tree' && (
         <>
-          {(search ? filtered : roots).map(l => (
-            <LocNode key={l.id} loc={l} locations={locations} expanded={expanded}
-              onToggle={toggle}
-              onEdit={e => { setEditing(e); setModalOpen(true) }}
-              onDelete={id => setConfirmId(id)}
-              onAddChild={openAdd} />
-          ))}
-          {locations.filter(l => l.parent_id && !locations.find(p => p.id === l.parent_id)).map(l => (
-            <LocNode key={l.id} loc={l} locations={locations} expanded={expanded}
-              onToggle={toggle}
-              onEdit={e => { setEditing(e); setModalOpen(true) }}
-              onDelete={id => setConfirmId(id)}
-              onAddChild={openAdd} />
-          ))}
+          {filtered.map(l => <LocNode key={l.id} loc={l} locations={locations} expanded={expanded} onToggle={toggle} onEdit={e => { setEditing(e); setModalOpen(true) }} onDelete={id => setConfirmId(id)} onAddChild={openAdd} />)}
+          {locations.filter(l => l.parent_id && !locations.find(p => p.id === l.parent_id)).map(l => <LocNode key={l.id} loc={l} locations={locations} expanded={expanded} onToggle={toggle} onEdit={e => { setEditing(e); setModalOpen(true) }} onDelete={id => setConfirmId(id)} onAddChild={openAdd} />)}
         </>
       )}
 
-      {view === 'table' && (
-        <FlatTable
-          locations={locations}
-          navSearch={navSearch}
-          onEdit={e => { setEditing(e); setModalOpen(true) }}
-          onDelete={id => setConfirmId(id)}
-          onAddChild={openAdd}
-        />
-      )}
+      {view === 'table' && <FlatTable locations={locations.filter(l => !autoOnly || l.auto_imported === true)} navSearch={navSearch} onEdit={e => { setEditing(e); setModalOpen(true) }} onDelete={id => setConfirmId(id)} onAddChild={openAdd} />}
 
-      <Modal open={modalOpen} onClose={() => { setModalOpen(false); setEditing(null) }}
-        title={`${editing?.id ? 'Edit' : 'Add'} Location`} color={TAB_COLOR}>
-        <EntryForm fields={LOC_FIELDS} entry={editing || {}} onSave={handleSave}
-          onCancel={() => { setModalOpen(false); setEditing(null) }} color={TAB_COLOR} db={db} />
+      <Modal open={modalOpen} onClose={() => { setModalOpen(false); setEditing(null) }} title={`${editing?.id ? 'Edit' : 'Add'} Location`} color={TAB_COLOR}>
+        <EntryForm fields={LOC_FIELDS} entry={editing || {}} onSave={handleSave} onCancel={() => { setModalOpen(false); setEditing(null) }} color={TAB_COLOR} db={db} />
       </Modal>
 
       {confirmId && (
         <div className="confirm-overlay open">
           <div className="confirm-box">
-            <p>Delete <strong>{locations.find(l => l.id === confirmId)?.name}</strong>?<br />
-              <span style={{ fontSize: '0.77em', color: 'var(--mut)' }}>Children will be detached, not deleted.</span>
-            </p>
+            <p>Delete <strong>{locations.find(l => l.id === confirmId)?.name}</strong>?<br /><span style={{ fontSize: '0.77em', color: 'var(--mut)' }}>Children will be detached, not deleted.</span></p>
             <button className="btn btn-outline btn-sm" onClick={() => setConfirmId(null)}>Cancel</button>{' '}
             <button className="btn btn-danger btn-sm" onClick={() => handleDelete(confirmId)}>Delete</button>
           </div>

--- a/src/tabs/Manuscript.jsx
+++ b/src/tabs/Manuscript.jsx
@@ -1,43 +1,36 @@
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { uid } from '../constants'
 import { parseSetting } from '../hooks/useDB'
 
 const BOOKS = ['Book 1', 'Book 2', 'Book 3']
 const MS_COLOR = '#aacc00'
-const MS_SIZE_LABELS = ['XS', 'S', 'M', 'L', 'XL']
-// XS = compact list, XL = full card with text preview
-const MS_SIZE_DETAIL = { XS: 0, S: 0, M: 60, L: 150, XL: 300 }
 const STATUSES = ['Draft', 'Revision', 'Polishing', 'Done']
 const STATUS_COLORS = { Draft: '#6b7280', Revision: '#f59e0b', Polishing: '#8b5cf6', Done: '#10b981' }
+const SHELF_COLS = { XS: 6, S: 4, M: 3, L: 2, XL: 1 }
+const TOC_COLS = { XS: 5, S: 4, M: 3, L: 2, XL: 1 }
+const navBtn = { fontSize: '0.85em', padding: '3px 10px', borderRadius: 6, background: 'none', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }
+const sizeBtn = active => ({ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, background: active ? MS_COLOR : 'none', color: active ? '#000' : 'var(--dim)', border: `1px solid ${active ? MS_COLOR : 'var(--brd)'}`, cursor: 'pointer' })
 
-// ── Light formatting helpers ──────────────────────────────────────
 function toHTML(text) {
   if (!text) return ''
-  // Normalize line endings
   let t = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
-  // Scene break *** on its own line
   t = t.replace(/^[ \t]*\*{3}[ \t]*$/gm, '\n<p style="text-align:center;letter-spacing:.3em">* * *</p>\n')
-  // HR ---
   t = t.replace(/^[ \t]*---[ \t]*$/gm, '<hr>')
-  // Inline formatting
   t = t.replace(/\*\*\*(.*?)\*\*\*/g, '<strong><em>$1</em></strong>')
   t = t.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
   t = t.replace(/\*(.*?)\*/g, '<em>$1</em>')
   t = t.replace(/_(.*?)_/g, '<em>$1</em>')
-  // Split into paragraphs on blank lines (1 or more)
   const paras = t.split(/\n{2,}/)
   return paras.map(p => {
     const trimmed = p.trim()
     if (!trimmed) return ''
-    // Already an HTML block (scene break, hr)
     if (trimmed.startsWith('<')) return trimmed
-    // Single newlines within a paragraph become line breaks
-    return '<p>' + trimmed.replace(/\n/g, '<br>') + '</p>'
+    const flowed = trimmed.replace(/\n+/g, ' ').replace(/\s+/g, ' ')
+    return '<p>' + flowed + '</p>'
   }).filter(Boolean).join('\n')
 }
 
 function toSubstack(text) {
-  // Clean HTML for Substack clipboard
   return '<div>' + toHTML(text) + '</div>'
 }
 
@@ -45,17 +38,16 @@ function stripFormatting(text) {
   return text.replace(/\*+/g, '').replace(/_/g, '')
 }
 
-// ── Word count ────────────────────────────────────────────────────
 function wordCount(text) {
   return (text || '').trim().split(/\s+/).filter(Boolean).length
 }
 
-// ── Formatting toolbar ────────────────────────────────────────────
 function FormatBar({ textareaRef, onUpdate }) {
   function wrap(before, after) {
     const ta = textareaRef.current
     if (!ta) return
-    const start = ta.selectionStart, end = ta.selectionEnd
+    const start = ta.selectionStart
+    const end = ta.selectionEnd
     const sel = ta.value.slice(start, end)
     const newVal = ta.value.slice(0, start) + before + sel + (after || before) + ta.value.slice(end)
     onUpdate(newVal)
@@ -64,33 +56,34 @@ function FormatBar({ textareaRef, onUpdate }) {
       ta.setSelectionRange(start + before.length, end + before.length)
     }, 0)
   }
+
   function insert(text) {
     const ta = textareaRef.current
     if (!ta) return
     const pos = ta.selectionStart
     const newVal = ta.value.slice(0, pos) + text + ta.value.slice(pos)
     onUpdate(newVal)
-    setTimeout(() => { ta.focus(); ta.setSelectionRange(pos + text.length, pos + text.length) }, 0)
+    setTimeout(() => {
+      ta.focus()
+      ta.setSelectionRange(pos + text.length, pos + text.length)
+    }, 0)
   }
 
   const btn = (label, title, action) => (
-    <button key={label} onClick={action} title={title}
-      style={{ fontSize: '0.85em', padding: '2px 8px', borderRadius: 5, background: 'var(--card)',
-        border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer', fontStyle: label === 'I' ? 'italic' : 'normal',
-        fontWeight: label === 'B' || label === 'BI' ? 700 : 400 }}>
+    <button key={label} onClick={action} title={title} style={{ fontSize: '0.85em', padding: '2px 8px', borderRadius: 5, background: 'var(--card)', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }}>
       {label}
     </button>
   )
 
   return (
     <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', padding: '6px 0', borderBottom: '1px solid var(--brd)', marginBottom: 8 }}>
-      {btn('I', 'Italic (*text*)', () => wrap('*', '*'))}
-      {btn('B', 'Bold (**text**)', () => wrap('**', '**'))}
-      {btn('BI', 'Bold Italic (***text***)', () => wrap('***', '***'))}
+      {btn('I', 'Italic', () => wrap('*', '*'))}
+      {btn('B', 'Bold', () => wrap('**', '**'))}
+      {btn('BI', 'Bold italic', () => wrap('***', '***'))}
       <div style={{ width: 1, background: 'var(--brd)', margin: '0 4px' }} />
-      {btn('— em dash', 'Insert em dash', () => insert('—'))}
-      {btn('… ellipsis', 'Insert ellipsis', () => insert('…'))}
-      {btn('* * * break', 'Scene break', () => insert('\n\n***\n\n'))}
+      {btn('—', 'Insert em dash', () => insert('—'))}
+      {btn('…', 'Insert ellipsis', () => insert('…'))}
+      {btn('* * *', 'Scene break', () => insert('\n\n***\n\n'))}
       <div style={{ width: 1, background: 'var(--brd)', margin: '0 4px' }} />
       {btn('" "', 'Curly double quotes', () => wrap('\u201c', '\u201d'))}
       {btn("' '", 'Curly single quotes', () => wrap('\u2018', '\u2019'))}
@@ -98,20 +91,32 @@ function FormatBar({ textareaRef, onUpdate }) {
   )
 }
 
-// ── Chapter editor ────────────────────────────────────────────────
-function ChapterEditor({ chapter, chars, scenes, onSave, onClose }) {
+function ChapterEditor({ chapter, chars, allChapters, onSave, onClose, onNavigateToChapter, onBackToShelf, onBackToTOC }) {
   const [text, setText] = useState(chapter.text || '')
   const [title, setTitle] = useState(chapter.title || '')
   const [status, setStatus] = useState(chapter.status || 'Draft')
   const [notes, setNotes] = useState(chapter.notes || '')
-  const [view, setView] = useState('edit') // 'edit' | 'preview' | 'split'
+  const [view, setView] = useState('edit')
   const [annotations, setAnnotations] = useState(chapter.annotations || [])
   const [showAnnotations, setShowAnnotations] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [fontSize, setFontSize] = useState(() => {
+    try { return parseFloat(localStorage.getItem('manuscript_fontsize')) || 1.0 } catch { return 1.0 }
+  })
+  const [indentParas, setIndentParas] = useState(() => {
+    try { return localStorage.getItem('manuscript_indent') !== 'off' } catch { return true }
+  })
   const textareaRef = useRef(null)
   const wc = wordCount(text)
 
-  // Detect which characters appear in this chapter
+  useEffect(() => {
+    setText(chapter.text || '')
+    setTitle(chapter.title || '')
+    setStatus(chapter.status || 'Draft')
+    setNotes(chapter.notes || '')
+    setAnnotations(chapter.annotations || [])
+  }, [chapter.id])
+
   const detectedChars = useMemo(() => {
     if (!text) return []
     return chars.filter(c => {
@@ -121,6 +126,29 @@ function ChapterEditor({ chapter, chars, scenes, onSave, onClose }) {
     })
   }, [text, chars])
 
+  const myIdx = allChapters.findIndex(c => c.id === chapter.id)
+  const prevChapter = myIdx > 0 ? allChapters[myIdx - 1] : null
+  const nextChapter = myIdx < allChapters.length - 1 ? allChapters[myIdx + 1] : null
+
+  function navPrev() { if (prevChapter) onNavigateToChapter(prevChapter.id) }
+  function navNext() { if (nextChapter) onNavigateToChapter(nextChapter.id) }
+
+  function changeFontSize(delta) {
+    setFontSize(s => {
+      const next = Math.max(0.7, Math.min(1.8, s + delta))
+      try { localStorage.setItem('manuscript_fontsize', String(next)) } catch {}
+      return next
+    })
+  }
+
+  function toggleIndent() {
+    setIndentParas(v => {
+      const next = !v
+      try { localStorage.setItem('manuscript_indent', next ? 'on' : 'off') } catch {}
+      return next
+    })
+  }
+
   function copyForSubstack() {
     const html = toSubstack(text)
     if (navigator.clipboard?.write) {
@@ -129,7 +157,6 @@ function ChapterEditor({ chapter, chars, scenes, onSave, onClose }) {
       navigator.clipboard.write([new ClipboardItem({ 'text/html': blob, 'text/plain': plain })])
         .then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000) })
         .catch(() => {
-          // Fallback: copy plain text
           navigator.clipboard.writeText(stripFormatting(text))
           setCopied(true); setTimeout(() => setCopied(false), 2000)
         })
@@ -144,125 +171,112 @@ function ChapterEditor({ chapter, chars, scenes, onSave, onClose }) {
   }
 
   const statusCol = STATUS_COLORS[status] || '#6b7280'
+  const previewBaseStyle = {
+    flex: 1,
+    overflowY: 'auto',
+    fontFamily: 'Georgia, serif',
+    color: 'var(--tx)',
+    maxWidth: '75ch',
+    margin: '0 auto',
+    '--p-indent': indentParas ? '2em' : '0',
+  }
 
   return (
     <div style={{ position: 'fixed', inset: 0, zIndex: 400, background: 'var(--bg)', display: 'flex', flexDirection: 'column' }}>
-      {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 14px',
-        borderBottom: '1px solid var(--brd)', background: 'var(--sf)', flexWrap: 'wrap' }}>
-        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1em', color: '#aacc00', flex: 1 }}>
-          {chapter.book} · Ch. {chapter.chapter_num}
-        </div>
-        <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Chapter title…"
-          style={{ flex: 2, minWidth: 200, fontSize: '1em', padding: '4px 8px', background: 'var(--card)',
-            border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', fontFamily: "'Cinzel',serif" }} />
-        {/* Status */}
-        <select value={status} onChange={e => setStatus(e.target.value)}
-          style={{ fontSize: '0.85em', padding: '4px 8px', background: `${statusCol}22`, border: `1px solid ${statusCol}`,
-            borderRadius: 6, color: statusCol, cursor: 'pointer' }}>
-          {STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
-        </select>
-        {/* View toggle */}
-        <div style={{ display: 'flex', gap: 3 }}>
-          {[['edit','✎'],['preview','👁'],['split','⧉']].map(([v,l]) => (
-            <button key={v} onClick={() => setView(v)}
-              style={{ fontSize: '0.85em', padding: '3px 8px', borderRadius: 6,
-                background: view === v ? 'var(--csc)' : 'none',
-                color: view === v ? '#000' : 'var(--dim)',
-                border: `1px solid ${view === v ? 'var(--csc)' : 'var(--brd)'}`, cursor: 'pointer' }}>{l}</button>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 14px', borderBottom: '1px solid var(--brd)', background: 'var(--card)', fontSize: '0.85em', flexWrap: 'wrap' }}>
+        <button onClick={onBackToShelf} style={navBtn}>← Shelf</button>
+        <button onClick={() => onBackToTOC(chapter.book)} style={navBtn}>← TOC</button>
+        <div style={{ width: 1, alignSelf: 'stretch', background: 'var(--brd)' }} />
+        <button onClick={navPrev} disabled={!prevChapter} style={{ ...navBtn, opacity: prevChapter ? 1 : 0.5, cursor: prevChapter ? 'pointer' : 'default' }}>← Prev Ch</button>
+        <button onClick={navNext} disabled={!nextChapter} style={{ ...navBtn, opacity: nextChapter ? 1 : 0.5, cursor: nextChapter ? 'pointer' : 'default' }}>Next Ch →</button>
+        <div style={{ width: 1, alignSelf: 'stretch', background: 'var(--brd)' }} />
+        <select value={chapter.id} onChange={e => onNavigateToChapter(e.target.value)} style={{ fontSize: '0.85em', padding: '3px 8px', background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', maxWidth: 240 }}>
+          {allChapters.map(c => (
+            <option key={c.id} value={c.id}>{c.book} · Ch {c.chapter_num} {c.title ? `· ${c.title}` : ''}</option>
           ))}
-        </div>
-        {/* Word count */}
-        <span style={{ fontSize: '0.77em', color: 'var(--mut)', whiteSpace: 'nowrap' }}>
-          {wc.toLocaleString()} words · ~{Math.round(wc / 250)} min read
-        </span>
-        {/* Copy for Substack */}
-        <button onClick={copyForSubstack}
-          style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 6, background: '#aacc00',
-            color: '#fff', border: 'none', cursor: 'pointer', whiteSpace: 'nowrap' }}>
-          {copied ? '✓ Copied!' : '📋 Copy for Substack'}
-        </button>
-        <button onClick={() => setShowAnnotations(a => !a)}
-          style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 6,
-            background: showAnnotations ? 'var(--cca)' : 'none',
-            color: showAnnotations ? '#000' : 'var(--dim)',
-            border: '1px solid var(--brd)', cursor: 'pointer' }}>
-          📝 Notes ({annotations.length})
-        </button>
-        <button onClick={save}
-          style={{ fontSize: '0.85em', padding: '5px 14px', borderRadius: 6, background: '#aacc00',
-            color: '#000', border: 'none', cursor: 'pointer', fontWeight: 700 }}>Save</button>
-        <button onClick={onClose}
-          style={{ background: 'none', border: 'none', color: 'var(--mut)', cursor: 'pointer', fontSize: '1.38em' }}>✕</button>
+        </select>
       </div>
 
-      {/* Detected characters */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 14px', borderBottom: '1px solid var(--brd)', background: 'var(--sf)', flexWrap: 'wrap' }}>
+        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1em', color: MS_COLOR, flex: 1 }}>{chapter.book} · Ch. {chapter.chapter_num}</div>
+        <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Chapter title..." style={{ flex: 2, minWidth: 200, fontSize: '1em', padding: '4px 8px', background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', fontFamily: "'Cinzel',serif" }} />
+        <select value={status} onChange={e => setStatus(e.target.value)} style={{ fontSize: '0.85em', padding: '4px 8px', background: `${statusCol}22`, border: `1px solid ${statusCol}`, borderRadius: 6, color: statusCol, cursor: 'pointer' }}>
+          {STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+        </select>
+        <div style={{ display: 'flex', gap: 3 }}>
+          {[['edit', '✎'], ['preview', '👁'], ['split', '⧉'], ['read', '📖']].map(([v, l]) => (
+            <button key={v} onClick={() => setView(v)} title={v} style={{ fontSize: '0.85em', padding: '3px 8px', borderRadius: 6, background: view === v ? 'var(--csc)' : 'none', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }}>{l}</button>
+          ))}
+        </div>
+        <button onClick={() => changeFontSize(-0.1)} style={{ fontSize: '0.85em', padding: '3px 8px', borderRadius: 6, background: 'none', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }}>A−</button>
+        <button onClick={() => changeFontSize(0.1)} style={{ fontSize: '0.85em', padding: '3px 8px', borderRadius: 6, background: 'none', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }}>A+</button>
+        <span style={{ fontSize: '0.69em', color: 'var(--mut)' }}>{Math.round(fontSize * 100)}%</span>
+        <button onClick={toggleIndent} style={{ fontSize: '0.85em', padding: '3px 8px', borderRadius: 6, background: 'none', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }}>{indentParas ? '⇥ Indent: ON' : '⇥ Indent: OFF'}</button>
+        <span style={{ fontSize: '0.77em', color: 'var(--mut)', whiteSpace: 'nowrap' }}>{wc.toLocaleString()} words · ~{Math.round(wc / 250)} min read</span>
+        <button onClick={copyForSubstack} style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 6, background: MS_COLOR, color: '#fff', border: 'none', cursor: 'pointer', whiteSpace: 'nowrap' }}>{copied ? '✓ Copied!' : '📋 Copy for Substack'}</button>
+        {view !== 'read' && <button onClick={() => setShowAnnotations(a => !a)} style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 6, background: showAnnotations ? 'var(--cca)' : 'none', color: showAnnotations ? '#000' : 'var(--dim)', border: '1px solid var(--brd)', cursor: 'pointer' }}>📝 Notes ({annotations.length})</button>}
+        <button onClick={save} style={{ fontSize: '0.85em', padding: '5px 14px', borderRadius: 6, background: MS_COLOR, color: '#000', border: 'none', cursor: 'pointer', fontWeight: 700 }}>Save</button>
+        <button onClick={onClose} style={{ background: 'none', border: 'none', color: 'var(--mut)', cursor: 'pointer', fontSize: '1.38em' }}>✕</button>
+      </div>
+
       {detectedChars.length > 0 && (
-        <div style={{ display: 'flex', gap: 6, padding: '4px 14px', background: 'var(--card)',
-          borderBottom: '1px solid var(--brd)', flexWrap: 'wrap', alignItems: 'center' }}>
+        <div style={{ display: 'flex', gap: 6, padding: '4px 14px', background: 'var(--card)', borderBottom: '1px solid var(--brd)', flexWrap: 'wrap', alignItems: 'center' }}>
           <span style={{ fontSize: '0.69em', color: 'var(--mut)', textTransform: 'uppercase', letterSpacing: '.05em' }}>Characters:</span>
           {detectedChars.map(c => (
-            <span key={c.id} style={{ fontSize: '0.77em', padding: '1px 8px', borderRadius: 10,
-              background: 'rgba(51,136,255,.15)', color: 'var(--cc)', border: '1px solid rgba(51,136,255,.3)' }}>
-              {c.display_name || c.name}
-            </span>
+            <span key={c.id} style={{ fontSize: '0.77em', padding: '1px 8px', borderRadius: 10, background: 'rgba(51,136,255,.15)', color: 'var(--cc)', border: '1px solid rgba(51,136,255,.3)' }}>{c.display_name || c.name}</span>
           ))}
         </div>
       )}
 
-      {/* Main content */}
       <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
-        {/* Editor */}
         {(view === 'edit' || view === 'split') && (
-          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', padding: '10px 14px', overflow: 'hidden',
-            borderRight: view === 'split' ? '1px solid var(--brd)' : 'none' }}>
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', padding: '10px 14px', overflow: 'hidden', borderRight: view === 'split' ? '1px solid var(--brd)' : 'none' }}>
             <FormatBar textareaRef={textareaRef} onUpdate={setText} />
-            <textarea ref={textareaRef} value={text} onChange={e => setText(e.target.value)}
-              style={{ flex: 1, resize: 'none', fontSize: '1em', lineHeight: 1.8, padding: '8px 0',
-                background: 'transparent', border: 'none', color: 'var(--tx)', outline: 'none',
-                fontFamily: 'Georgia, serif', overflowY: 'auto' }}
-              placeholder="Paste or type your chapter here. Use *italic*, **bold**, — for em dash, *** for scene break." />
+            <textarea ref={textareaRef} value={text} onChange={e => setText(e.target.value)} style={{ flex: 1, resize: 'none', fontSize: `${fontSize}em`, lineHeight: 1.8, padding: '8px 0', background: 'transparent', border: 'none', color: 'var(--tx)', outline: 'none', fontFamily: 'Georgia, serif', overflowY: 'auto' }} placeholder="Paste or type your chapter here. Use *italic*, **bold**, — for em dash, *** for scene break." />
           </div>
         )}
 
-        {/* Preview */}
         {(view === 'preview' || view === 'split') && (
-          <div style={{ flex: 1, padding: '10px 40px', overflowY: 'auto',
-            fontFamily: 'Georgia, serif', fontSize: '1.08em', lineHeight: 1.9, color: 'var(--tx)' }}
-            dangerouslySetInnerHTML={{ __html: toHTML(text) || '<p style="color:var(--mut)">Nothing to preview yet.</p>' }} />
+          <div style={{ ...previewBaseStyle, fontSize: `${fontSize * 1.08}em`, lineHeight: 1.9, padding: '20px 40px' }}>
+            <style>{`
+              .ms-preview p { text-indent: var(--p-indent, 2em); margin: 0; }
+              .ms-preview p + p { margin-top: 0; }
+              .ms-preview p:first-of-type { text-indent: 0; }
+            `}</style>
+            <div className="ms-preview" dangerouslySetInnerHTML={{ __html: toHTML(text) || '<p style="color:var(--mut)">Nothing to preview yet.</p>' }} />
+          </div>
         )}
 
-        {/* Annotations panel */}
-        {showAnnotations && (
+        {view === 'read' && (
+          <div style={{ ...previewBaseStyle, fontSize: `${fontSize * 1.2}em`, lineHeight: 2, padding: '40px 60px' }}>
+            <style>{`
+              .ms-preview p { text-indent: var(--p-indent, 2em); margin: 0; }
+              .ms-preview p + p { margin-top: 0; }
+              .ms-preview p:first-of-type { text-indent: 0; }
+            `}</style>
+            <div className="ms-preview" dangerouslySetInnerHTML={{ __html: toHTML(text) || '<p style="color:var(--mut)">Nothing to read yet.</p>' }} />
+          </div>
+        )}
+
+        {showAnnotations && view !== 'read' && (
           <div style={{ width: 280, borderLeft: '1px solid var(--brd)', padding: '10px 14px', overflowY: 'auto', flexShrink: 0 }}>
             <div style={{ fontFamily: "'Cinzel',serif", fontSize: '0.92em', color: 'var(--cca)', marginBottom: 10 }}>📝 Chapter Notes</div>
-            <textarea value={notes} onChange={e => setNotes(e.target.value)} rows={6}
-              placeholder="Chapter-level notes, to-do, revision thoughts…"
-              style={{ width: '100%', fontSize: '0.85em', padding: '6px 8px', background: 'var(--card)',
-                border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', resize: 'vertical', boxSizing: 'border-box', marginBottom: 12 }} />
-            <div style={{ fontSize: '0.77em', fontWeight: 700, color: 'var(--mut)', textTransform: 'uppercase', letterSpacing: '.05em', marginBottom: 8 }}>
-              Passage Flags
-            </div>
-            {annotations.length === 0 && (
-              <div style={{ fontSize: '0.77em', color: 'var(--mut)' }}>No passage flags yet. Select text and add a flag.</div>
-            )}
-            {annotations.map((ann, i) => (
-              <div key={ann.id} style={{ marginBottom: 8, padding: '6px 8px', background: 'var(--card)',
-                borderLeft: '3px solid var(--cfl)', borderRadius: '0 6px 6px 0', fontSize: '0.77em' }}>
+            <textarea value={notes} onChange={e => setNotes(e.target.value)} rows={6} placeholder="Chapter-level notes, to-do, revision thoughts..." style={{ width: '100%', fontSize: '0.85em', padding: '6px 8px', background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', resize: 'vertical', boxSizing: 'border-box', marginBottom: 12 }} />
+            <div style={{ fontSize: '0.77em', fontWeight: 700, color: 'var(--mut)', textTransform: 'uppercase', letterSpacing: '.05em', marginBottom: 8 }}>Passage Flags</div>
+            {annotations.length === 0 && <div style={{ fontSize: '0.77em', color: 'var(--mut)' }}>No passage flags yet. Select text and add a flag.</div>}
+            {annotations.map(ann => (
+              <div key={ann.id} style={{ marginBottom: 8, padding: '6px 8px', background: 'var(--card)', borderLeft: '3px solid var(--cfl)', borderRadius: '0 6px 6px 0', fontSize: '0.77em' }}>
                 <div style={{ color: 'var(--cfl)', fontStyle: 'italic', marginBottom: 3 }}>"{ann.passage}"</div>
                 <div style={{ color: 'var(--tx)' }}>{ann.note}</div>
-                <button onClick={() => setAnnotations(a => a.filter(x => x.id !== ann.id))}
-                  style={{ fontSize: '0.69em', color: '#ff3355', background: 'none', border: 'none', cursor: 'pointer', padding: 0, marginTop: 4 }}>Remove</button>
+                <button onClick={() => setAnnotations(a => a.filter(x => x.id !== ann.id))} style={{ fontSize: '0.69em', color: '#ff3355', background: 'none', border: 'none', cursor: 'pointer', padding: 0, marginTop: 4 }}>Remove</button>
               </div>
             ))}
           </div>
         )}
       </div>
 
-      {/* Formatting guide */}
-      <div style={{ padding: '4px 14px', background: 'var(--card)', borderTop: '1px solid var(--brd)',
-        fontSize: '0.69em', color: 'var(--mut)', display: 'flex', gap: 16, flexWrap: 'wrap' }}>
-        {[['*text*','italic'],['**text**','bold'],['***text***','bold italic'],['—','em dash'],['…','ellipsis'],['***','scene break']].map(([code, label]) => (
+      <div style={{ padding: '4px 14px', background: 'var(--card)', borderTop: '1px solid var(--brd)', fontSize: '0.69em', color: 'var(--mut)', display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+        {[['*text*', 'italic'], ['**text**', 'bold'], ['***text***', 'bold italic'], ['—', 'em dash'], ['…', 'ellipsis'], ['***', 'scene break']].map(([code, label]) => (
           <span key={code}><code style={{ color: 'var(--cca)' }}>{code}</code> = {label}</span>
         ))}
       </div>
@@ -270,35 +284,31 @@ function ChapterEditor({ chapter, chars, scenes, onSave, onClose }) {
   )
 }
 
-// ── Main Manuscript tab ───────────────────────────────────────────
 export default function Manuscript({ db, navSearch }) {
-  const tabColor = MS_COLOR
   const chapters = (db.db.manuscript || []).sort((a, b) => {
     const bi = BOOKS.indexOf(a.book) - BOOKS.indexOf(b.book)
     if (bi !== 0) return bi
     return (parseInt(a.chapter_num) || 0) - (parseInt(b.chapter_num) || 0)
   })
   const chars = db.db.characters || []
-  const scenes = db.db.scenes || []
-
   const [search, setSearch] = useState('')
-
-  // Sync top nav search
-  useEffect(() => { setSearch(navSearch || '') }, [navSearch])
-
   const [filterBook, setFilterBook] = useState('all')
-  const [tocBook, setTocBook] = useState(null) // null = shelf, 'Book 1' etc = TOC view
-  const [coverLightbox, setCoverLightbox] = useState(null) // cover image for lightbox
+  const [tocBook, setTocBook] = useState(null)
+  const [coverLightbox, setCoverLightbox] = useState(null)
   const [editCovers, setEditCovers] = useState(false)
-  const [colSize, setColSize] = useState(() => { try { return localStorage.getItem('colsize_manuscript') || 'M' } catch { return 'M' } })
-  function changeColSize(sz) { setColSize(sz); try { localStorage.setItem('colsize_manuscript', sz) } catch {} }
   const [filterStatus, setFilterStatus] = useState('all')
   const [editingChapter, setEditingChapter] = useState(null)
-  const [confirmDelete, setConfirmDelete] = useState(null)
   const [addingChapter, setAddingChapter] = useState(false)
   const [newForm, setNewForm] = useState({ book: 'Book 1', chapter_num: '', title: '' })
+  const [shelfSize, setShelfSize] = useState(() => {
+    try { return localStorage.getItem('manuscript_shelf_size') || 'M' } catch { return 'M' }
+  })
+  const [tocSize, setTocSize] = useState(() => {
+    try { return localStorage.getItem('manuscript_toc_size') || 'M' } catch { return 'M' }
+  })
 
-  // Escape key: close lightbox — must be after all useState declarations
+  useEffect(() => { setSearch(navSearch || '') }, [navSearch])
+
   useEffect(() => {
     function onKey(e) {
       if (e.key === 'Escape' && coverLightbox) setCoverLightbox(null)
@@ -307,25 +317,60 @@ export default function Manuscript({ db, navSearch }) {
     return () => window.removeEventListener('keydown', onKey)
   }, [coverLightbox])
 
+  useEffect(() => {
+    function onExpand(e) {
+      const targetId = e?.detail?.id
+      if (!targetId) return
+      const entry = chapters.find(x => x.id === targetId)
+      if (!entry) return
+      setEditingChapter(entry)
+    }
+    window.addEventListener('gcomp_expand', onExpand)
+    return () => window.removeEventListener('gcomp_expand', onExpand)
+  }, [chapters])
+
   const filtered = chapters.filter(ch => {
     const mb = filterBook === 'all' || ch.book === filterBook
     const ms = filterStatus === 'all' || ch.status === filterStatus
-    const mq = !search || (ch.title||'').toLowerCase().includes(search.toLowerCase()) ||
-      (ch.text||'').toLowerCase().includes(search.toLowerCase())
+    const mq = !search || (ch.title || '').toLowerCase().includes(search.toLowerCase()) || (ch.text || '').toLowerCase().includes(search.toLowerCase())
     return mb && ms && mq
   })
 
-  // Stats
   const totalWords = chapters.reduce((sum, ch) => sum + (ch.word_count || wordCount(ch.text || '')), 0)
-  const byBook = BOOKS.map(b => ({
-    book: b,
-    chapters: chapters.filter(ch => ch.book === b),
-    words: chapters.filter(ch => ch.book === b).reduce((s, ch) => s + (ch.word_count || wordCount(ch.text||'')), 0)
+  const byBook = BOOKS.map(book => ({
+    book,
+    chapters: chapters.filter(ch => ch.book === book),
+    words: chapters.filter(ch => ch.book === book).reduce((sum, ch) => sum + (ch.word_count || wordCount(ch.text || '')), 0),
   }))
+
+  function changeShelfSize(sz) {
+    setShelfSize(sz)
+    try { localStorage.setItem('manuscript_shelf_size', sz) } catch {}
+  }
+
+  function changeTocSize(sz) {
+    setTocSize(sz)
+    try { localStorage.setItem('manuscript_toc_size', sz) } catch {}
+  }
 
   function saveChapter(ch) {
     db.upsertEntry('manuscript', ch)
     setEditingChapter(null)
+  }
+
+  function navigateToChapter(chId) {
+    const ch = chapters.find(c => c.id === chId)
+    if (ch) setEditingChapter(ch)
+  }
+
+  function backToShelf() {
+    setEditingChapter(null)
+    setTocBook(null)
+  }
+
+  function backToTOC(book) {
+    setEditingChapter(null)
+    setTocBook(book)
   }
 
   function addChapter() {
@@ -351,274 +396,172 @@ export default function Manuscript({ db, navSearch }) {
     <div>
       {!tocBook && (
         <>
-          {/* Book shelf — portrait cards, image only on cover face */}
-          <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 6 }}>
-            <button onClick={() => setEditCovers(e => !e)}
-              style={{ fontSize: '0.77em', padding: '3px 12px', borderRadius: 6, cursor: 'pointer',
-                border: `1px solid ${editCovers ? '#aacc00' : 'var(--brd)'}`,
-                background: editCovers ? '#aacc0022' : 'none',
-                color: editCovers ? '#aacc00' : 'var(--dim)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center', marginBottom: 10, flexWrap: 'wrap' }}>
+            <div style={{ display: 'flex', gap: 3 }}>
+              {['XS', 'S', 'M', 'L', 'XL'].map(l => <button key={l} onClick={() => changeShelfSize(l)} style={sizeBtn(shelfSize === l)}>{l}</button>)}
+            </div>
+            <button onClick={() => setEditCovers(e => !e)} style={{ fontSize: '0.77em', padding: '3px 12px', borderRadius: 6, cursor: 'pointer', border: `1px solid ${editCovers ? MS_COLOR : 'var(--brd)'}`, background: editCovers ? '#aacc0022' : 'none', color: editCovers ? MS_COLOR : 'var(--dim)' }}>
               {editCovers ? '✓ Done' : '✎ Edit covers'}
             </button>
           </div>
-          <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap', justifyContent: 'center', marginBottom: 24 }}>
-            {byBook.map(({ book, chapters: chs, words }) => {
-              const meta = parseSetting(db.settings?.[`manuscript_book_${book.replace(/ /g,'_')}`])
+          <div style={{ display: 'grid', gridTemplateColumns: `repeat(${SHELF_COLS[shelfSize]}, minmax(0, 1fr))`, gap: 20, marginBottom: 24 }}>
+            {byBook.map(({ book, chapters: bookChapters, words }) => {
+              const meta = parseSetting(db.settings?.[`manuscript_book_${book.replace(/ /g, '_')}`])
               const cover = meta.cover || ''
-              const accent = meta.accent || '#aacc00'
+              const accent = meta.accent || MS_COLOR
               return (
-                <div key={book} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: 200 }}>
-                  <div style={{
-                    width: 200, height: 300, borderRadius: '4px 10px 10px 4px', overflow: 'hidden',
-                    border: `3px solid ${accent}`, background: cover ? 'transparent' : accent + '22',
-                    boxShadow: '4px 6px 18px rgba(0,0,0,.55)', cursor: 'pointer',
-                  }} onClick={() => {
-                        const meta2 = parseSetting(db.settings?.[`manuscript_book_${book.replace(/ /g,'_')}`])
-                        const cover2 = meta2?.cover || ''
-                        if (cover2) {
-                          setCoverLightbox({ book, cover: cover2 })  // lightbox → then TOC on close
-                        } else {
-                          setTocBook(book)
-                          setFilterBook(book)
-                        }
-                      }}>
+                <div key={book} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                  <div style={{ width: '100%', maxWidth: 200, aspectRatio: '2 / 3', borderRadius: '4px 10px 10px 4px', overflow: 'hidden', border: `3px solid ${accent}`, background: cover ? 'transparent' : `${accent}22`, boxShadow: '4px 6px 18px rgba(0,0,0,.55)', cursor: 'pointer' }} onClick={() => {
+                    const meta2 = parseSetting(db.settings?.[`manuscript_book_${book.replace(/ /g, '_')}`])
+                    const cover2 = meta2?.cover || ''
+                    if (cover2) setCoverLightbox({ book, cover: cover2 })
+                    else { setTocBook(book); setFilterBook(book) }
+                  }}>
                     {cover
                       ? <img src={cover} alt={book} style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
-                      : <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                          <span style={{ fontSize: '2.46em', opacity: 0.25 }}>📖</span>
-                        </div>
+                      : <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><span style={{ fontSize: '2.2em', opacity: 0.25 }}>📖</span></div>
                     }
                   </div>
-                  {/* Edit controls — shown in edit mode */}
                   {editCovers && (
                     <div style={{ marginTop: 6, display: 'flex', gap: 6, alignItems: 'center', justifyContent: 'center' }}>
-                      <label title="Upload cover image" style={{ cursor: 'pointer', fontSize: '1.08em', color: '#aacc00' }}>
+                      <label title="Upload cover image" style={{ cursor: 'pointer', fontSize: '1.08em', color: MS_COLOR }}>
                         🖼
-                        <input type="file" accept="image/*" style={{ display: 'none' }}
-                          onChange={ev => {
-                            const file = ev.target.files?.[0]; if (!file) return
-                            const reader = new FileReader()
-                            reader.onload = e2 => {
-                              const key = `manuscript_book_${book.replace(/ /g,'_')}`
-                              const existing = parseSetting(db.settings?.[key])
-                              db.saveSetting(key, JSON.stringify({ ...existing, cover: e2.target.result }))
-                            }
-                            reader.readAsDataURL(file)
-                          }} />
-                      </label>
-                      <input type="color" value={accent} title="Accent colour"
-                        style={{ width: 22, height: 22, padding: 0, border: 'none', borderRadius: 3, cursor: 'pointer' }}
-                        onChange={ev => {
-                          const key = `manuscript_book_${book.replace(/ /g,'_')}`
-                          const existing = parseSetting(db.settings?.[key])
-                          db.saveSetting(key, JSON.stringify({ ...existing, accent: ev.target.value }))
-                        }} />
-                      {cover && (
-                        <button title="Remove cover" style={{ background: 'none', border: 'none', color: '#ff3355', cursor: 'pointer', padding: 0 }}
-                          onClick={() => {
-                            const key = `manuscript_book_${book.replace(/ /g,'_')}`
+                        <input type="file" accept="image/*" style={{ display: 'none' }} onChange={ev => {
+                          const file = ev.target.files?.[0]
+                          if (!file) return
+                          const reader = new FileReader()
+                          reader.onload = e2 => {
+                            const key = `manuscript_book_${book.replace(/ /g, '_')}`
                             const existing = parseSetting(db.settings?.[key])
-                            db.saveSetting(key, JSON.stringify({ ...existing, cover: '' }))
-                          }}>✕</button>
+                            db.saveSetting(key, JSON.stringify({ ...existing, cover: e2.target.result }))
+                          }
+                          reader.readAsDataURL(file)
+                        }} />
+                      </label>
+                      <input type="color" value={accent} title="Accent colour" style={{ width: 22, height: 22, padding: 0, border: 'none', borderRadius: 3, cursor: 'pointer' }} onChange={ev => {
+                        const key = `manuscript_book_${book.replace(/ /g, '_')}`
+                        const existing = parseSetting(db.settings?.[key])
+                        db.saveSetting(key, JSON.stringify({ ...existing, accent: ev.target.value }))
+                      }} />
+                      {cover && (
+                        <button title="Remove cover" style={{ background: 'none', border: 'none', color: '#ff3355', cursor: 'pointer', padding: 0 }} onClick={() => {
+                          const key = `manuscript_book_${book.replace(/ /g, '_')}`
+                          const existing = parseSetting(db.settings?.[key])
+                          db.saveSetting(key, JSON.stringify({ ...existing, cover: '' }))
+                        }}>✕</button>
                       )}
                     </div>
                   )}
                   <div style={{ marginTop: editCovers ? 4 : 8, textAlign: 'center', width: '100%' }}>
                     <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1em', color: accent, fontWeight: 700 }}>{book}</div>
-                    <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginTop: 2 }}>{chs.length} chapters · {words.toLocaleString()} words</div>
+                    <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginTop: 2 }}>{bookChapters.length} chapters · {words.toLocaleString()} words</div>
                     <div style={{ display: 'flex', gap: 2, marginTop: 4, flexWrap: 'wrap', justifyContent: 'center' }}>
-                      {STATUSES.map(s => { const n = chs.filter(ch2 => ch2.status === s).length; if (!n) return null
-                        return <span key={s} style={{ fontSize: '0.62em', padding: '1px 5px', borderRadius: 3,
-                          background: `${STATUS_COLORS[s]}22`, color: STATUS_COLORS[s] }}>{n} {s}</span>
+                      {STATUSES.map(s => {
+                        const n = bookChapters.filter(ch => ch.status === s).length
+                        if (!n) return null
+                        return <span key={s} style={{ fontSize: '0.62em', padding: '1px 5px', borderRadius: 3, background: `${STATUS_COLORS[s]}22`, color: STATUS_COLORS[s] }}>{n} {s}</span>
                       })}
                     </div>
                   </div>
                 </div>
               )
             })}
-            <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', padding: '0 8px' }}>
-              <div style={{ fontFamily: "'Cinzel',serif", fontSize: '0.77em', color: 'var(--dim)', marginBottom: 2 }}>Total</div>
-              <div style={{ fontSize: '1.69em', fontWeight: 700, color: 'var(--tx)' }}>{totalWords.toLocaleString()}</div>
-              <div style={{ fontSize: '0.77em', color: 'var(--mut)' }}>words · {chapters.length} ch</div>
-            </div>
+          </div>
+          <div style={{ marginBottom: 16, textAlign: 'center' }}>
+            <div style={{ fontFamily: "'Cinzel',serif", fontSize: '0.77em', color: 'var(--dim)', marginBottom: 2 }}>Total</div>
+            <div style={{ fontSize: '1.69em', fontWeight: 700, color: 'var(--tx)' }}>{totalWords.toLocaleString()}</div>
+            <div style={{ fontSize: '0.77em', color: 'var(--mut)' }}>words · {chapters.length} ch</div>
           </div>
         </>
       )}
 
-      {/* Toolbar */}
       <div className="tbar" style={{ flexWrap: 'wrap', gap: 6 }}>
-        <div style={{ display: 'flex', gap: 3, marginRight: 'auto' }}>
-          {MS_SIZE_LABELS.map(l => (
-            <button key={l} onClick={() => changeColSize(l)} style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, background: colSize===l ? MS_COLOR : 'none', color: colSize===l ? '#000' : 'var(--dim)', border: `1px solid ${colSize===l ? MS_COLOR : 'var(--brd)'}`, cursor: 'pointer' }}>{l}</button>
-          ))}
-        </div>
-        <input className="sx" placeholder="Search chapters and text…" value={search}
-          onChange={e => setSearch(e.target.value)} style={{ flex: 1 }} />
-        <select value={filterBook} onChange={e => setFilterBook(e.target.value)}
-          style={{ fontSize: '0.77em', padding: '4px 8px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
+        {tocBook && (
+          <div style={{ display: 'flex', gap: 3, marginRight: 'auto' }}>
+            {['XS', 'S', 'M', 'L', 'XL'].map(l => <button key={l} onClick={() => changeTocSize(l)} style={sizeBtn(tocSize === l)}>{l}</button>)}
+          </div>
+        )}
+        {!tocBook && <div style={{ marginRight: 'auto' }} />}
+        <input className="sx" placeholder="Search chapters and text..." value={search} onChange={e => setSearch(e.target.value)} style={{ flex: 1 }} />
+        <select value={filterBook} onChange={e => setFilterBook(e.target.value)} style={{ fontSize: '0.77em', padding: '4px 8px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
           <option value="all">All books</option>
           {BOOKS.map(b => <option key={b} value={b}>{b}</option>)}
         </select>
-        <select value={filterStatus} onChange={e => setFilterStatus(e.target.value)}
-          style={{ fontSize: '0.77em', padding: '4px 8px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
+        <select value={filterStatus} onChange={e => setFilterStatus(e.target.value)} style={{ fontSize: '0.77em', padding: '4px 8px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
           <option value="all">All statuses</option>
           {STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
         </select>
-        <button className="btn btn-primary btn-sm" style={{ background: '#aacc00' }}
-          onClick={() => setAddingChapter(true)}>+ Add Chapter</button>
+        <button className="btn btn-primary btn-sm" style={{ background: MS_COLOR }} onClick={() => setAddingChapter(true)}>+ Add Chapter</button>
       </div>
 
-      {/* Add chapter form */}
       {addingChapter && (
-        <div style={{ padding: '10px 14px', background: 'var(--card)', border: '1px solid var(--csc)',
-          borderRadius: 8, marginBottom: 10, display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'flex-end' }}>
+        <div style={{ padding: '10px 14px', background: 'var(--card)', border: '1px solid var(--csc)', borderRadius: 8, marginBottom: 10, display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'flex-end' }}>
           <div className="field" style={{ margin: 0 }}>
             <label>Book</label>
-            <select value={newForm.book} onChange={e => setNewForm(p => ({ ...p, book: e.target.value }))}>
-              {BOOKS.map(b => <option key={b} value={b}>{b}</option>)}
-            </select>
+            <select value={newForm.book} onChange={e => setNewForm(p => ({ ...p, book: e.target.value }))}>{BOOKS.map(b => <option key={b} value={b}>{b}</option>)}</select>
           </div>
           <div className="field" style={{ margin: 0 }}>
             <label>Chapter #</label>
-            <input type="number" value={newForm.chapter_num} onChange={e => setNewForm(p => ({ ...p, chapter_num: e.target.value }))}
-              style={{ width: 80 }} placeholder="e.g. 1" />
+            <input type="number" value={newForm.chapter_num} onChange={e => setNewForm(p => ({ ...p, chapter_num: e.target.value }))} style={{ width: 80 }} placeholder="e.g. 1" />
           </div>
           <div className="field" style={{ flex: 1, margin: 0 }}>
             <label>Title (optional)</label>
-            <input value={newForm.title} onChange={e => setNewForm(p => ({ ...p, title: e.target.value }))}
-              placeholder="e.g. Barn power manifestation" />
+            <input value={newForm.title} onChange={e => setNewForm(p => ({ ...p, title: e.target.value }))} placeholder="e.g. Barn power manifestation" />
           </div>
-          <button className="btn btn-primary btn-sm" style={{ background: '#aacc00' }} onClick={addChapter}>Add</button>
+          <button className="btn btn-primary btn-sm" style={{ background: MS_COLOR }} onClick={addChapter}>Add</button>
           <button className="btn btn-outline btn-sm" onClick={() => setAddingChapter(false)}>Cancel</button>
         </div>
       )}
 
-      {/* ── TOC view (single book) ── */}
       {tocBook && (
         <div style={{ marginBottom: 16 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16, paddingBottom: 10, borderBottom: '1px solid var(--brd)' }}>
-            <button onClick={() => { setTocBook(null); setFilterBook('all'); setCoverLightbox(null) }}
-              style={{ fontSize: '0.85em', padding: '4px 12px', borderRadius: 6,
-                background: 'none', border: '1px solid var(--brd)', color: 'var(--dim)', cursor: 'pointer' }}>
-              ← Back to Shelf
-            </button>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16, paddingBottom: 10, borderBottom: '1px solid var(--brd)', flexWrap: 'wrap' }}>
+            <button onClick={() => { setTocBook(null); setFilterBook('all'); setCoverLightbox(null) }} style={{ fontSize: '0.85em', padding: '4px 12px', borderRadius: 6, background: 'none', border: '1px solid var(--brd)', color: 'var(--dim)', cursor: 'pointer' }}>← Back to Shelf</button>
             <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.15em', color: MS_COLOR, fontWeight: 700 }}>{tocBook}</div>
-            <div style={{ fontSize: '0.77em', color: 'var(--mut)', marginLeft: 'auto' }}>
-              {chapters.filter(c => c.book === tocBook).length} chapters · {chapters.filter(c => c.book === tocBook).reduce((s, c) => s + (c.word_count || wordCount(c.text || '')), 0).toLocaleString()} words
-            </div>
+            <div style={{ fontSize: '0.77em', color: 'var(--mut)', marginLeft: 'auto' }}>{chapters.filter(c => c.book === tocBook).length} chapters · {chapters.filter(c => c.book === tocBook).reduce((sum, c) => sum + (c.word_count || wordCount(c.text || '')), 0).toLocaleString()} words</div>
           </div>
-        </div>
-      )}
 
-      {tocBook && (
-        <>
-          {/* Chapter list */}
           {filtered.length === 0 && (
             <div className="empty">
               <div className="empty-icon">📖</div>
               <p>{chapters.length === 0 ? 'No chapters yet.' : 'No chapters match your filters.'}</p>
-              {chapters.length === 0 && (
-                <button className="btn btn-primary" style={{ background: '#aacc00' }} onClick={() => setAddingChapter(true)}>
-                  + Add First Chapter
-                </button>
-              )}
             </div>
           )}
 
-          {BOOKS.filter(b => b === tocBook).map(book => {
-            const bookChapters = filtered.filter(ch => ch.book === book)
-            if (!bookChapters.length) return null
-            return (
-              <div key={book} style={{ marginBottom: 20 }}>
-                <div style={{ display: 'grid', gap: 2 }}>
-                  {bookChapters.map(ch => {
-                    const wc = ch.word_count || wordCount(ch.text || '')
-                    const sc = STATUS_COLORS[ch.status] || '#6b7280'
-                    return (
-                      <div key={ch.id}
-                        style={{ display: 'grid', gridTemplateColumns: '90px 1fr auto', gap: 10, alignItems: 'baseline',
-                          padding: '8px 10px', borderRadius: 4, cursor: 'pointer', transition: 'background .12s ease' }}
-                        onMouseEnter={e => { e.currentTarget.style.background = 'var(--card)' }}
-                        onMouseLeave={e => { e.currentTarget.style.background = 'transparent' }}
-                        onClick={() => setEditingChapter(ch)}>
-                        <div style={{ fontSize: '0.75em', color: tabColor, letterSpacing: '.04em', textTransform: 'uppercase' }}>
-                          Chapter {ch.chapter_num}
-                        </div>
-                        <div style={{ fontFamily: 'Georgia, serif', fontSize: '1.02em', color: 'var(--tx)' }}>
-                          {ch.title || <span style={{ color: 'var(--mut)', fontStyle: 'italic' }}>Untitled</span>}
-                        </div>
-                        <div style={{ fontSize: '0.75em', color: 'var(--mut)', whiteSpace: 'nowrap' }}>
-                          {wc.toLocaleString()} words · <span style={{ color: sc }}>{ch.status || 'Draft'}</span>
-                        </div>
-                      </div>
-                    )
-                  })}
+          <div style={{ display: 'grid', gridTemplateColumns: `repeat(${TOC_COLS[tocSize]}, minmax(0, 1fr))`, gap: 8 }}>
+            {filtered.filter(ch => ch.book === tocBook).map(ch => {
+              const wc = ch.word_count || wordCount(ch.text || '')
+              const sc = STATUS_COLORS[ch.status] || '#6b7280'
+              return (
+                <div key={ch.id} id={`gcomp-entry-${ch.id}`} style={{ padding: '10px 12px', borderRadius: 8, cursor: 'pointer', background: 'var(--card)', border: '1px solid var(--brd)' }} onClick={() => setEditingChapter(ch)}>
+                  <div style={{ fontSize: '0.75em', color: MS_COLOR, letterSpacing: '.04em', textTransform: 'uppercase', marginBottom: 4 }}>Chapter {ch.chapter_num}</div>
+                  <div style={{ fontFamily: 'Georgia, serif', fontSize: '1.02em', color: 'var(--tx)' }}>{ch.title || <span style={{ color: 'var(--mut)', fontStyle: 'italic' }}>Untitled</span>}</div>
+                  <div style={{ fontSize: '0.75em', color: 'var(--mut)', marginTop: 6 }}>{wc.toLocaleString()} words · <span style={{ color: sc }}>{ch.status || 'Draft'}</span></div>
                 </div>
-              </div>
-            )
-          })}
-        </>
+              )
+            })}
+          </div>
+        </div>
       )}
 
-      {/* ── Cover lightbox overlay ── */}
       {coverLightbox && (
-        <div style={{
-          position: 'fixed', inset: 0, zIndex: 500,
-          background: 'rgba(0,0,0,.92)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          cursor: 'pointer',
-        }} onClick={() => {
-          // Click outside image = back to shelf
-          setCoverLightbox(null)
-        }}>
+        <div style={{ position: 'fixed', inset: 0, zIndex: 500, background: 'rgba(0,0,0,.92)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }} onClick={() => setCoverLightbox(null)}>
           <div style={{ position: 'relative', maxWidth: '40vw', maxHeight: '80vh' }}>
-            <img src={coverLightbox.cover} alt={coverLightbox.book}
-              style={{ maxWidth: '100%', maxHeight: '80vh', objectFit: 'contain',
-                borderRadius: 8, boxShadow: '0 8px 48px rgba(0,0,0,.8)',
-                border: '2px solid rgba(255,255,255,.15)', cursor: 'pointer' }}
-              onClick={e => {
-                e.stopPropagation()
-                const book = coverLightbox.book
-                setCoverLightbox(null)
-                setTocBook(book)
-                setFilterBook(book)
-              }} />
-            <div style={{ position: 'absolute', bottom: -40, left: 0, right: 0,
-              textAlign: 'center', color: 'rgba(255,255,255,.5)', fontSize: '0.85em' }}>
-              Click image to open book · Click outside or ✕ to close
-            </div>
-            <button onClick={e => { e.stopPropagation(); setCoverLightbox(null) }}
-              style={{ position: 'absolute', top: -12, right: -12, width: 28, height: 28,
-                borderRadius: '50%', background: 'rgba(0,0,0,.7)', border: '1px solid rgba(255,255,255,.2)',
-                color: 'rgba(255,255,255,.7)', fontSize: '1em', cursor: 'pointer',
-                display: 'flex', alignItems: 'center', justifyContent: 'center' }}>✕</button>
+            <img src={coverLightbox.cover} alt={coverLightbox.book} style={{ maxWidth: '100%', maxHeight: '80vh', objectFit: 'contain', borderRadius: 8, boxShadow: '0 8px 48px rgba(0,0,0,.8)', border: '2px solid rgba(255,255,255,.15)', cursor: 'pointer' }} onClick={e => {
+              e.stopPropagation()
+              const book = coverLightbox.book
+              setCoverLightbox(null)
+              setTocBook(book)
+              setFilterBook(book)
+            }} />
+            <div style={{ position: 'absolute', bottom: -40, left: 0, right: 0, textAlign: 'center', color: 'rgba(255,255,255,.5)', fontSize: '0.85em' }}>Click image to open book · Click outside or ✕ to close</div>
+            <button onClick={e => { e.stopPropagation(); setCoverLightbox(null) }} style={{ position: 'absolute', top: -12, right: -12, width: 28, height: 28, borderRadius: '50%', background: 'rgba(0,0,0,.7)', border: '1px solid rgba(255,255,255,.2)', color: 'rgba(255,255,255,.7)', fontSize: '1em', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>✕</button>
           </div>
         </div>
       )}
 
-      {/* Chapter editor */}
       {editingChapter && (
-        <ChapterEditor
-          chapter={editingChapter}
-          chars={chars}
-          scenes={scenes}
-          onSave={saveChapter}
-          onClose={() => setEditingChapter(null)}
-        />
-      )}
-
-      {/* Delete confirm */}
-      {confirmDelete && (
-        <div className="confirm-overlay open">
-          <div className="confirm-box">
-            <p>Delete this chapter? <strong>This cannot be undone.</strong></p>
-            <button className="btn btn-outline btn-sm" onClick={() => setConfirmDelete(null)}>Cancel</button>{' '}
-            <button className="btn btn-danger btn-sm" onClick={() => {
-              db.deleteEntry('manuscript', confirmDelete)
-              setConfirmDelete(null)
-            }}>Delete</button>
-          </div>
-        </div>
+        <ChapterEditor chapter={editingChapter} chars={chars} allChapters={chapters} onSave={saveChapter} onClose={() => setEditingChapter(null)} onNavigateToChapter={navigateToChapter} onBackToShelf={backToShelf} onBackToTOC={backToTOC} />
       )}
     </div>
   )

--- a/src/tabs/Notes.jsx
+++ b/src/tabs/Notes.jsx
@@ -1,157 +1,66 @@
-import { useState, useEffect } from 'react'
-import Modal from '../components/common/Modal'
-import { uid } from '../constants'
+import { useEffect, useState } from 'react'
+import StickiesView from './notes/StickiesView'
+import JournalView from './notes/JournalView'
 
 const NOTES_COLOR = '#ffcc00'
-const SIZE_COLS_N = { XS: 4, S: 3, M: 2, L: 1, XL: 1 }
-const SIZE_LABELS_N = ['XS', 'S', 'M', 'L']
 
-const NOTE_CATS = ['General', 'Canon', 'Brainstorm', 'Research', 'Todo', 'Quote', 'Other']
+export default function Notes(props) {
+  const { db } = props
+  const [pendingExpandId, setPendingExpandId] = useState(null)
+  const [subTab, setSubTab] = useState(() => {
+    try { return localStorage.getItem('notes_subtab') || 'stickies' } catch { return 'stickies' }
+  })
 
-export default function Notes({ db, navSearch }) {
-  const notes = db.db.notes || []
-  const [search, setSearch] = useState('')
+  useEffect(() => {
+    function onExpand(e) {
+      const targetId = e?.detail?.id
+      if (!targetId) return
+      const note = (db.db.notes || []).find(x => x.id === targetId)
+      if (note) {
+        pick('journal')
+        setPendingExpandId(targetId)
+        return
+      }
+      const sticky = (db.db.journal_captures || []).find(x => x.id === targetId)
+      if (sticky) {
+        pick('stickies')
+        setPendingExpandId(targetId)
+      }
+    }
+    window.addEventListener('gcomp_expand', onExpand)
+    return () => window.removeEventListener('gcomp_expand', onExpand)
+  }, [db.db.notes, db.db.journal_captures])
 
-  // Sync top nav search
-  useEffect(() => { setSearch(navSearch || '') }, [navSearch])
-  const [catFilter, setCatFilter] = useState('all')
-  const [modalOpen, setModalOpen] = useState(false)
-  const [editing, setEditing] = useState(null)
-  const [confirmId, setConfirmId] = useState(null)
-  const [colSize, setColSize] = useState(() => { try { return localStorage.getItem('colsize_notes') || 'M' } catch { return 'M' } })
-  const [viewNote, setViewNote] = useState(null)
-  function changeColSize(sz) { setColSize(sz); try { localStorage.setItem('colsize_notes', sz) } catch {} }
-
-  useEffect(() => { setSearch(navSearch || '') }, [navSearch])
-
-  const filtered = notes.filter(n => {
-    const ms = !search || JSON.stringify(n).toLowerCase().includes(search.toLowerCase())
-    const mc = catFilter === 'all' || n.category === catFilter
-    return ms && mc
-  }).sort((a, b) => new Date(b.updated||0) - new Date(a.updated||0))
-
-  const usedCats = [...new Set(notes.map(n => n.category).filter(Boolean))]
-
-  function handleSave(form) {
-    db.upsertEntry('notes', { ...form, id: form.id || uid(), updated: new Date().toISOString() })
-    setModalOpen(false); setEditing(null)
+  function pick(t) {
+    setSubTab(t)
+    try { localStorage.setItem('notes_subtab', t) } catch {}
   }
 
   return (
     <div>
-      <div className="tbar">
-        <div style={{ display: 'flex', gap: 3, marginRight: 'auto' }}>
-          {SIZE_LABELS_N.map(l => (
-            <button key={l} onClick={() => changeColSize(l)} style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, background: colSize===l ? NOTES_COLOR : 'none', color: colSize===l ? '#000' : 'var(--dim)', border: `1px solid ${colSize===l ? NOTES_COLOR : 'var(--brd)'}`, cursor: 'pointer' }}>{l}</button>
-          ))}
-        </div>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.08em', color: NOTES_COLOR }}>📝 Notes & Lore</div>
-        <button className="btn btn-primary btn-sm" style={{ background: NOTES_COLOR, color: '#000' }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ New Note</button>
-      </div>
-
-      <div className="tbar" style={{ padding: '0 0 8px' }}>
-        <input className="sx" placeholder="Search notes…" value={search} onChange={e => setSearch(e.target.value)} />
-      </div>
-
-      <div style={{ display: 'flex', gap: 3, flexWrap: 'wrap', marginBottom: 10 }}>
-        <button className={`fp ${catFilter==='all'?'active':''}`} style={{ color: '#ff6b6b' }} onClick={() => setCatFilter('all')}>All</button>
-        {usedCats.map(c => (
-          <button key={c} className={`fp ${catFilter===c?'active':''}`} style={{ color: '#ff6b6b' }} onClick={() => setCatFilter(c)}>{c}</button>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+        {[['stickies', '📌 Stickies'], ['journal', '📝 Journal']].map(([k, l]) => (
+          <button
+            key={k}
+            onClick={() => pick(k)}
+            style={{
+              padding: '6px 14px',
+              borderRadius: 8,
+              border: `1px solid ${subTab === k ? NOTES_COLOR : 'var(--brd)'}`,
+              background: subTab === k ? NOTES_COLOR : 'transparent',
+              color: subTab === k ? '#000' : NOTES_COLOR,
+              fontSize: 11,
+              fontWeight: 700,
+              cursor: 'pointer',
+            }}
+          >
+            {l}
+          </button>
         ))}
       </div>
 
-      {!filtered.length && (
-        <div className="empty">
-          <div className="empty-icon">📝</div>
-          <p>No notes yet.</p>
-          <p style={{ fontSize: '0.85em', color: 'var(--mut)', maxWidth: 300, margin: '8px auto' }}>For quick notes, brainstorms, canon reminders, research snippets, and anything that doesn't fit elsewhere.</p>
-          <button className="btn btn-primary" style={{ background: '#ff6b6b', color: '#000' }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add Note</button>
-        </div>
-      )}
-
-      <div style={{ display: 'grid', gridTemplateColumns: SIZE_COLS_N[colSize] > 1 ? `repeat(${SIZE_COLS_N[colSize]}, minmax(0,1fr))` : '1fr', gap: 6 }}>
-        {filtered.map((n, i) => (
-          <div key={n.id} className="entry-card" style={{ '--card-color': 'var(--cw)', background: i%2===1?'rgba(255,255,255,.01)':undefined, cursor: 'pointer' }}
-            onClick={() => setViewNote(n)}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-              {n.title && <div className="entry-title" style={{ fontSize: '1em' }}>{n.title}</div>}
-              {n.category && <span className="badge" style={{ color: '#ff6b6b', borderColor: 'rgba(255,204,0,.3)', flexShrink: 0, marginLeft: 8 }}>{n.category}</span>}
-            </div>
-            <div style={{ fontSize: '0.92em', color: 'var(--dim)', lineHeight: 1.5, marginTop: 4, whiteSpace: 'pre-wrap' }}>
-              {n.content?.length > 300 ? n.content.slice(0, 300) + '…' : n.content}
-            </div>
-            <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 6 }}>
-              {n.updated ? new Date(n.updated).toLocaleString() : ''}
-            </div>
-            <div className="entry-actions">
-              <button className="btn btn-sm btn-outline" style={{ color: '#ff6b6b', borderColor: '#ff6b6b' }} onClick={() => { setEditing(n); setModalOpen(true) }}>✎ Edit</button>
-              <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544' }} onClick={() => setConfirmId(n.id)}>✕</button>
-            </div>
-          </div>
-        ))}
-      </div>
-
-
-      {/* View popup */}
-      {viewNote && (
-        <div className="modal-overlay open" onClick={() => setViewNote(null)}>
-          <div className="modal-box" onClick={e => e.stopPropagation()} style={{ maxWidth: 640 }}>
-            <button className="modal-close" onClick={() => setViewNote(null)}>✕</button>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 10, flexWrap: 'wrap', gap: 8 }}>
-              {viewNote.title && <div className="modal-title" style={{ color: NOTES_COLOR }}>{viewNote.title}</div>}
-              {viewNote.category && <span className="badge" style={{ color: NOTES_COLOR, borderColor: 'rgba(255,204,0,.3)' }}>{viewNote.category}</span>}
-            </div>
-            <div style={{ fontSize: '0.92em', color: 'var(--tx)', lineHeight: 1.6, whiteSpace: 'pre-wrap', marginBottom: 12 }}>{viewNote.content}</div>
-            <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginBottom: 12 }}>
-              {viewNote.updated ? new Date(viewNote.updated).toLocaleString() : ''}
-            </div>
-            <div className="modal-actions">
-              <button className="btn btn-outline" onClick={() => { setViewNote(null); setEditing(viewNote); setModalOpen(true) }}>✎ Edit</button>
-              <button className="btn btn-outline" onClick={() => setViewNote(null)}>Close</button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      <Modal open={modalOpen} onClose={() => { setModalOpen(false); setEditing(null) }} title={editing?.id ? 'Edit Note' : 'Add Note'} color="var(--cw)">
-        {(editing !== null) && <NoteForm note={editing} onSave={handleSave} onCancel={() => { setModalOpen(false); setEditing(null) }} cats={NOTE_CATS} />}
-      </Modal>
-
-      {confirmId && (
-        <div className="confirm-overlay open">
-          <div className="confirm-box">
-            <p>Delete this note?</p>
-            <button className="btn btn-outline btn-sm" onClick={() => setConfirmId(null)}>Cancel</button>{' '}
-            <button className="btn btn-danger btn-sm" onClick={() => { db.deleteEntry('notes', confirmId); setConfirmId(null); setViewNote(null) }}>Delete</button>
-          </div>
-        </div>
-      )}
+      {subTab === 'stickies' && <StickiesView {...props} pendingExpandId={pendingExpandId} clearPendingExpandId={() => setPendingExpandId(null)} />}
+      {subTab === 'journal' && <JournalView {...props} pendingExpandId={pendingExpandId} clearPendingExpandId={() => setPendingExpandId(null)} />}
     </div>
-  )
-}
-
-function NoteForm({ note, onSave, onCancel, cats }) {
-  const [form, setForm] = useState({ title: '', category: 'General', content: '', ...note })
-  const s = k => e => setForm(p => ({ ...p, [k]: e.target.value }))
-  return (
-    <>
-      <div className="field-row">
-        <div className="field"><label>Title (optional)</label><input value={form.title} onChange={s('title')} placeholder="Note title…" /></div>
-        <div className="field"><label>Category</label>
-          <select value={form.category} onChange={s('category')}>
-            {cats.map(c => <option key={c} value={c}>{c}</option>)}
-          </select>
-        </div>
-      </div>
-      <div className="field"><label>Content *</label>
-        <textarea value={form.content} onChange={s('content')} placeholder="Write your note…" style={{ minHeight: 120 }} />
-      </div>
-      <div className="modal-actions">
-        <button className="btn btn-outline" onClick={onCancel}>Cancel</button>
-        <button className="btn btn-primary" style={{ background: '#ff6b6b', color: '#000' }} onClick={() => onSave(form)}>
-          {note.id ? 'Save' : 'Add Note'}
-        </button>
-      </div>
-    </>
   )
 }

--- a/src/tabs/Questions.jsx
+++ b/src/tabs/Questions.jsx
@@ -1,32 +1,23 @@
 import GenericListTab from '../components/common/GenericListTab'
 
 const Q_FIELDS = [
-  { k: 'name',           l: 'Question',       t: 'text', r: true },
-  { k: 'related_topic',  l: 'Topic',          t: 'text' },
-  { k: 'priority',       l: 'Priority',       t: 'sel', o: ['','High','Medium','Low'] },
+  { k: 'name', l: 'Question', t: 'text', r: true },
+  { k: 'related_topic', l: 'Topic', t: 'text' },
+  { k: 'priority', l: 'Priority', t: 'sel', o: ['', 'High', 'Medium', 'Low'] },
   { k: 'session_raised', l: 'Session Raised', t: 'text' },
-  { k: 'detail',         l: 'Detail',         t: 'ta' },
-]
-
-const Q_FILTERS = [
-  { key: 'priority', label: 'Priority', options: [
-    { value: 'High', label: '🔴 High' },
-    { value: 'Medium', label: '🟡 Medium' },
-    { value: 'Low', label: '🟢 Low' },
-  ]},
-  { key: 'status', label: 'Status', options: [
-    { value: 'open', label: 'Open' },
-    { value: 'locked', label: 'Locked' },
-    { value: 'provisional', label: 'Provisional' },
-  ]},
+  { k: 'detail', l: 'Detail', t: 'ta' },
 ]
 
 export default function Questions({ db, navSearch }) {
   return (
     <GenericListTab
-      catKey="questions" color="#c77dff" icon="❓"
-      label="Open Questions" fields={Q_FIELDS} db={db}
-      navSearch={navSearch} extraFilters={Q_FILTERS}
+      catKey="questions"
+      color="#c77dff"
+      icon="❓"
+      label="Open Questions"
+      fields={Q_FIELDS}
+      db={db}
+      navSearch={navSearch}
     />
   )
 }

--- a/src/tabs/Scenes.jsx
+++ b/src/tabs/Scenes.jsx
@@ -1,7 +1,8 @@
-import { useState, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Modal from '../components/common/Modal'
 import EntryForm from '../components/common/EntryForm'
 import { uid, RAINBOW, lerpColor, BKS } from '../constants'
+import { scrollAndFlashEntry } from '../components/common/entryNav'
 
 const SC_COLOR = '#38b000'
 const SCENE_FIELDS = [
@@ -59,6 +60,21 @@ export default function Scenes({ db, navSearch }) {
   const [modalOpen, setModalOpen] = useState(false)
   const [editing, setEditing] = useState(null)
   const [confirmId, setConfirmId] = useState(null)
+  const [autoOnly, setAutoOnly] = useState(false)
+  const autoCount = scenes.filter(s => s.auto_imported === true).length
+
+  useEffect(() => {
+    function onExpand(e) {
+      const targetId = e?.detail?.id
+      if (!targetId) return
+      const entry = scenes.find(x => x.id === targetId)
+      if (!entry) return
+      setPopup(entry)
+      window.setTimeout(() => scrollAndFlashEntry(targetId), 50)
+    }
+    window.addEventListener('gcomp_expand', onExpand)
+    return () => window.removeEventListener('gcomp_expand', onExpand)
+  }, [scenes])
 
   function changeCPR(sz) {
     setCardsPerRow(sz)
@@ -125,8 +141,9 @@ export default function Scenes({ db, navSearch }) {
   const filtered = useMemo(() => coloredScenes.filter(s => {
     const mb = bookFilter === 'all' || s.book === bookFilter
     const ms = !search || JSON.stringify(s).toLowerCase().includes(search.toLowerCase())
-    return mb && ms
-  }), [coloredScenes, bookFilter, search])
+    const ma = !autoOnly || s.auto_imported === true
+    return mb && ms && ma
+  }), [coloredScenes, bookFilter, search, autoOnly])
 
   const cpr = CARDS_PER_ROW[cardsPerRow] || 4
 
@@ -186,6 +203,15 @@ export default function Scenes({ db, navSearch }) {
         </div>
         <input className="sx" placeholder="Search scenes…" value={search}
           onChange={e => setSearch(e.target.value)} style={{ maxWidth: 180 }} />
+        {autoCount > 0 && (
+          <button onClick={() => setAutoOnly(v => !v)}
+            style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12,
+              border: `1px solid ${autoOnly ? '#ffcc00' : 'var(--brd)'}`,
+              background: autoOnly ? '#ffcc0022' : 'none',
+              color: autoOnly ? '#ffcc00' : 'var(--dim)', cursor: 'pointer' }}>
+            📥 Auto-imported ({autoCount})
+          </button>
+        )}
         <button className="btn btn-primary btn-sm" style={{ background: SC_COLOR, color: '#000', marginLeft: 'auto' }}
           onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add</button>
       </div>
@@ -287,7 +313,7 @@ export default function Scenes({ db, navSearch }) {
                             )}
 
                             {/* Card */}
-                            <div onClick={() => setPopup(scene)}
+                            <div id={`gcomp-entry-${scene.id}`} onClick={() => setPopup(scene)}
                               style={{
                                 flex: 1, minWidth: 0,
                                 background: 'var(--card)',

--- a/src/tabs/SessionLog.jsx
+++ b/src/tabs/SessionLog.jsx
@@ -27,9 +27,9 @@ const SECTION_LABELS = [
 
 const FEATURE_TAB_OPTIONS = [
   'dashboard','wiki','glossary','characters','familytree','world','locations','map',
-  'manuscript','scenes','timeline','eras','calendar',
-  'inventory','wardrobe','items','flags','questions','canon','spellings',
-  'notes','journal','tools','sessionlog',
+  'manuscript','scenes','timeline','calendar',
+  'inventory','flags','questions','canon','spellings',
+  'notes','tools','sessionlog',
 ]
 
 const FEATURE_REGISTRY_SEED = [

--- a/src/tabs/SessionLog.jsx
+++ b/src/tabs/SessionLog.jsx
@@ -406,7 +406,7 @@ export default function SessionLog({ db, goTo }) {
       setSessions(local)
       if (hasSupabase) {
         const remote = await sbLoadSessions()
-        if (remote) { setSessions(remote); lsSave(remote) }
+        if (remote !== null) { setSessions(remote); lsSave(remote) }
       }
       const localFeatures = lsLoadFeatureRegistry()
       let loadedFeatures = localFeatures

--- a/src/tabs/Spellings.jsx
+++ b/src/tabs/Spellings.jsx
@@ -1,26 +1,23 @@
 import GenericListTab from '../components/common/GenericListTab'
 
 const SP_FIELDS = [
-  { k: 'name',       l: 'Term',       t: 'text', r: true },
-  { k: 'working',    l: 'Working',    t: 'text' },
+  { k: 'name', l: 'Term', t: 'text', r: true },
+  { k: 'working', l: 'Working', t: 'text' },
   { k: 'alternates', l: 'Alternates', t: 'text' },
-  { k: 'detail',     l: 'Notes',      t: 'ta' },
-]
-
-const SP_FILTERS = [
-  { key: 'status', label: 'Status', options: [
-    { value: 'locked', label: 'Locked' },
-    { value: 'provisional', label: 'Provisional' },
-    { value: 'open', label: 'Open' },
-  ]},
+  { k: 'detail', l: 'Notes', t: 'ta' },
 ]
 
 export default function Spellings({ db, navSearch }) {
   return (
     <GenericListTab
-      catKey="spellings" color="#ff69b4" icon="✎"
-      label="Spellings" fields={SP_FIELDS} db={db}
-      navSearch={navSearch} extraFilters={SP_FILTERS}
+      catKey="spellings"
+      color="#ff69b4"
+      icon="✎"
+      label="Spellings"
+      fields={SP_FIELDS}
+      db={db}
+      navSearch={navSearch}
+      getJumpName={e => e.word || e.name}
     />
   )
 }

--- a/src/tabs/Timeline.jsx
+++ b/src/tabs/Timeline.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect } from 'react'
 import Modal from '../components/common/Modal'
 import EntryForm from '../components/common/EntryForm'
 import { highlight, SL, uid } from '../constants'
+import { scrollAndFlashEntry } from '../components/common/entryNav'
 
 const TL_FIELDS = [
   { k: 'name',          l: 'Event',          t: 'text', r: true },
@@ -36,6 +37,8 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
   const [modalOpen, setModalOpen] = useState(false)
   const [editing, setEditing] = useState(null)
   const [confirmId, setConfirmId] = useState(null)
+  const [autoOnly, setAutoOnly] = useState(false)
+  const autoCount = events.filter(e => e.auto_imported === true).length
 
   useEffect(() => {
     if (crossLink?.search) {
@@ -48,7 +51,23 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
       }
       clearCrossLink?.()
     }
-  }, [crossLink])
+  }, [crossLink, clearCrossLink, events])
+
+  useEffect(() => {
+    function onExpand(e) {
+      const targetId = e?.detail?.id
+      if (!targetId) return
+      const entry = events.find(x => x.id === targetId)
+      if (!entry) return
+      setExpanded(targetId)
+      setEditing(entry)
+      setModalOpen(true)
+      setTrackPopup(null)
+      window.setTimeout(() => scrollAndFlashEntry(targetId), 50)
+    }
+    window.addEventListener('gcomp_expand', onExpand)
+    return () => window.removeEventListener('gcomp_expand', onExpand)
+  }, [events])
   const [showVisual, setShowVisual] = useState(true)
   const [listSort, setListSort] = useState('order')
   const [visualFilter, setVisualFilter] = useState('all') // independent era filter for visual track
@@ -108,7 +127,8 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
     .filter(e => {
       const ms = !search || JSON.stringify(e).toLowerCase().includes(search.toLowerCase())
       const me = filterEra === 'all' || e.era === filterEra
-      return ms && me
+      const ma = !autoOnly || e.auto_imported === true
+      return ms && me && ma
     })
     .sort((a,b) => {
       if (listSort === 'alpha') return (a.name||'').localeCompare(b.name||'')
@@ -181,6 +201,15 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
             <button key={era} className={`fp ${filterEra===era?'active':''}`} style={{ background: filterEra===era ? ERA_BANDS[era]||'rgba(255,255,255,.05)':'' }} onClick={() => setFilterEra(filterEra===era?'all':era)}>{era}</button>
           ))}
         </div>
+        {autoCount > 0 && (
+          <button onClick={() => setAutoOnly(v => !v)}
+            style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12,
+              border: `1px solid ${autoOnly ? '#ffcc00' : 'var(--brd)'}`,
+              background: autoOnly ? '#ffcc0022' : 'none',
+              color: autoOnly ? '#ffcc00' : 'var(--dim)', cursor: 'pointer' }}>
+            📥 Auto-imported ({autoCount})
+          </button>
+        )}
       </div>
 
       {/* Visual track */}
@@ -342,7 +371,7 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
         {sorted.map((e, i) => {
           const isOpen = colCount === 1 || expanded === e.id  // XL auto-expands all
           return (
-            <div key={e.id} className="entry-card" style={{ breakInside: 'avoid', marginBottom: 6, '--card-color': 'var(--ct)' }} onClick={() => setExpanded(isOpen?null:e.id)}>
+            <div key={e.id} id={`gcomp-entry-${e.id}`} className="entry-card" style={{ breakInside: 'avoid', marginBottom: 6, '--card-color': 'var(--ct)' }} onClick={() => setExpanded(isOpen?null:e.id)}>
               <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                 <div className="entry-title" dangerouslySetInnerHTML={{ __html: highlight(e.name||'', search) }} />
                 <div style={{ fontSize: 10, color: 'var(--ct)' }}>{[e.date_hc, e.date_mnaerah].filter(Boolean).join(' / ')}</div>

--- a/src/tabs/Wiki.jsx
+++ b/src/tabs/Wiki.jsx
@@ -1,9 +1,10 @@
 const SIZE_COLS_WIKI = { XS: 4, S: 3, M: 2, L: 2, XL: 1 }
 
-import { useState, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Modal from '../components/common/Modal'
 import FilterPopup from '../components/common/FilterPopup'
 import { uid } from '../constants'
+import { scrollAndFlashEntry } from '../components/common/entryNav'
 
 const WIKI_CATS = [
   'Lore', 'World History', 'Cosmology', 'Power System',
@@ -302,6 +303,21 @@ export default function Wiki({ db, navSearch }) {
   const [filterValues, setFilterValues] = useState({})
   const [editing, setEditing] = useState(null) // null = list, {} = new, {id,...} = edit
   const [confirmId, setConfirmId] = useState(null)
+  const [autoOnly, setAutoOnly] = useState(false)
+  const autoCount = articles.filter(a => a.auto_imported === true).length
+
+  useEffect(() => {
+    function onExpand(e) {
+      const targetId = e?.detail?.id
+      if (!targetId) return
+      const entry = articles.find(x => x.id === targetId)
+      if (!entry) return
+      setEditing(entry)
+      window.setTimeout(() => scrollAndFlashEntry(targetId), 50)
+    }
+    window.addEventListener('gcomp_expand', onExpand)
+    return () => window.removeEventListener('gcomp_expand', onExpand)
+  }, [articles])
 
   const filtered = articles.filter(a => {
     const ms = !(navSearch||'') || JSON.stringify(a).toLowerCase().includes((navSearch||'').toLowerCase())
@@ -309,7 +325,8 @@ export default function Wiki({ db, navSearch }) {
     // Extra popup filters
     const selCats = filterValues['category'] || []
     const matchPopupCat = selCats.length === 0 || selCats.includes(a.category)
-    return ms && mc && matchPopupCat
+    const matchAuto = !autoOnly || a.auto_imported === true
+    return ms && mc && matchPopupCat && matchAuto
   })
 
   function handleSave(article) {
@@ -341,6 +358,11 @@ export default function Wiki({ db, navSearch }) {
           values={filterValues}
           onChange={(key, vals) => setFilterValues(prev => ({ ...prev, [key]: vals }))}
         />
+        {autoCount > 0 && (
+          <button onClick={() => setAutoOnly(v => !v)} style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: `1px solid ${autoOnly ? '#ffcc00' : 'var(--brd)'}`, background: autoOnly ? '#ffcc0022' : 'none', color: autoOnly ? '#ffcc00' : 'var(--dim)', cursor: 'pointer' }}>
+            📥 Auto-imported ({autoCount})
+          </button>
+        )}
         <button className="btn btn-primary btn-sm" style={{ background: '#ff69b4' }} onClick={() => setEditing({})}>+ New Article</button>
       </div>
 
@@ -365,7 +387,7 @@ export default function Wiki({ db, navSearch }) {
 
       <div style={{ display: 'grid', gridTemplateColumns: {'XS':4,'S':3,'M':2,'L':1,'XL':1}[colSize] || 2 > 1 ? `repeat(${ {'XS':4,'S':3,'M':2,'L':1,'XL':1}[colSize] || 2 }, minmax(0,1fr))` : '1fr', gap: 6 }}>
         {filtered.map(a => (
-          <div key={a.id} className="entry-card" style={{ '--card-color': '#ff69b4' }}>
+          <div key={a.id} id={`gcomp-entry-${a.id}`} className="entry-card" style={{ '--card-color': '#ff69b4' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
               <div>
                 <div className="entry-title">{a.title}</div>

--- a/src/tabs/World.jsx
+++ b/src/tabs/World.jsx
@@ -1,26 +1,21 @@
 import GenericListTab from '../components/common/GenericListTab'
 
 const WORLD_FIELDS = [
-  { k: 'name',     l: 'Topic',    t: 'text', r: true },
+  { k: 'name', l: 'Topic', t: 'text', r: true },
   { k: 'subtopic', l: 'Subtopic', t: 'text' },
-  { k: 'detail',   l: 'Detail',   t: 'ta' },
-]
-
-const WORLD_FILTERS = [
-  { key: 'status', label: 'Status', options: [
-    { value: 'locked', label: 'Locked' },
-    { value: 'provisional', label: 'Provisional' },
-    { value: 'open', label: 'Open' },
-    { value: 'exploratory', label: 'Exploratory' },
-  ]},
+  { k: 'detail', l: 'Detail', t: 'ta' },
 ]
 
 export default function World({ db, navSearch }) {
   return (
     <GenericListTab
-      catKey="world" color="#ff8c00" icon="🌐"
-      label="World Entries" fields={WORLD_FIELDS} db={db}
-      navSearch={navSearch} extraFilters={WORLD_FILTERS}
+      catKey="world"
+      color="#ff8c00"
+      icon="🌐"
+      label="World Entries"
+      fields={WORLD_FIELDS}
+      db={db}
+      navSearch={navSearch}
     />
   )
 }

--- a/src/tabs/notes/JournalView.jsx
+++ b/src/tabs/notes/JournalView.jsx
@@ -1,0 +1,239 @@
+import { useEffect, useMemo, useState } from 'react'
+import Modal from '../../components/common/Modal'
+import { uid } from '../../constants'
+import StickyEditModal from './StickyEditModal'
+import { NOTES_COLOR, normalizeSticky, scrollAndFlashEntry, sortJournalPins, STICKY_COLORS } from './stickyShared'
+
+const SIZE_COLS_N = { XS: 4, S: 3, M: 2, L: 1, XL: 1 }
+const SIZE_LABELS_N = ['XS', 'S', 'M', 'L']
+const NOTE_CATS = ['General', 'Canon', 'Brainstorm', 'Research', 'Todo', 'Quote', 'Other']
+
+function NoteForm({ note, onSave, onCancel, cats }) {
+  const [form, setForm] = useState({ title: '', category: 'General', content: '', ...note })
+  const s = k => e => setForm(p => ({ ...p, [k]: e.target.value }))
+  return (
+    <>
+      <div className="field-row">
+        <div className="field"><label>Title (optional)</label><input value={form.title} onChange={s('title')} placeholder="Note title..." /></div>
+        <div className="field"><label>Category</label>
+          <select value={form.category} onChange={s('category')}>
+            {cats.map(c => <option key={c} value={c}>{c}</option>)}
+          </select>
+        </div>
+      </div>
+      <div className="field"><label>Content *</label>
+        <textarea value={form.content} onChange={s('content')} placeholder="Write your note..." style={{ minHeight: 120 }} />
+      </div>
+      <div className="modal-actions">
+        <button className="btn btn-outline" onClick={onCancel}>Cancel</button>
+        <button className="btn btn-primary" style={{ background: '#ff6b6b', color: '#000' }} onClick={() => onSave(form)}>
+          {note.id ? 'Save' : 'Add Note'}
+        </button>
+      </div>
+    </>
+  )
+}
+
+export default function JournalView({ db, navSearch, pendingExpandId, clearPendingExpandId }) {
+  const notes = db.db.notes || []
+  const captures = useMemo(() => (db.db.journal_captures || []).map((c, i) => normalizeSticky(c, i)), [db.db.journal_captures])
+  const [search, setSearch] = useState('')
+  const [catFilter, setCatFilter] = useState('all')
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editing, setEditing] = useState(null)
+  const [confirmId, setConfirmId] = useState(null)
+  const [colSize, setColSize] = useState(() => { try { return localStorage.getItem('colsize_notes') || 'M' } catch { return 'M' } })
+  const [viewNote, setViewNote] = useState(null)
+  const [sidebarEdit, setSidebarEdit] = useState(null)
+  const [dragId, setDragId] = useState(null)
+
+  useEffect(() => { setSearch(navSearch || '') }, [navSearch])
+
+  useEffect(() => {
+    if (!pendingExpandId) return
+    const entry = notes.find(n => n.id === pendingExpandId)
+    if (!entry) return
+    setEditing(entry)
+    setModalOpen(true)
+    window.setTimeout(() => scrollAndFlashEntry(entry.id), 50)
+    clearPendingExpandId?.()
+  }, [pendingExpandId, notes, clearPendingExpandId])
+
+  const filtered = notes.filter(n => {
+    const ms = !search || JSON.stringify(n).toLowerCase().includes(search.toLowerCase())
+    const mc = catFilter === 'all' || n.category === catFilter
+    return ms && mc
+  }).sort((a, b) => new Date(b.updated || 0) - new Date(a.updated || 0))
+
+  const usedCats = [...new Set(notes.map(n => n.category).filter(Boolean))]
+  const pinnedStickies = sortJournalPins(captures.filter(c => c.pinned_journal))
+  const isMobile = typeof window !== 'undefined' ? window.innerWidth < 700 : false
+
+  function changeColSize(sz) { setColSize(sz); try { localStorage.setItem('colsize_notes', sz) } catch {} }
+
+  function handleSave(form) {
+    db.upsertEntry('notes', { ...form, id: form.id || uid(), updated: new Date().toISOString() })
+    setModalOpen(false)
+    setEditing(null)
+  }
+
+  function saveSticky(updated) {
+    db.upsertEntry('journal_captures', { ...updated, updated_at: new Date().toISOString() })
+    setSidebarEdit(null)
+  }
+
+  function handleSidebarDrop(targetId) {
+    if (!dragId || dragId === targetId) return
+    const ordered = sortJournalPins(pinnedStickies)
+    const from = ordered.findIndex(s => s.id === dragId)
+    const to = ordered.findIndex(s => s.id === targetId)
+    if (from < 0 || to < 0) return
+    const next = [...ordered]
+    const [moved] = next.splice(from, 1)
+    next.splice(to, 0, moved)
+    next.forEach((sticky, idx) => {
+      db.upsertEntry('journal_captures', { ...sticky, journal_sort_order: idx, updated_at: new Date().toISOString() })
+    })
+    setDragId(null)
+  }
+
+  return (
+    <div>
+      <div className="tbar">
+        <div style={{ display: 'flex', gap: 3, marginRight: 'auto' }}>
+          {SIZE_LABELS_N.map(l => (
+            <button key={l} onClick={() => changeColSize(l)} style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, background: colSize === l ? NOTES_COLOR : 'none', color: colSize === l ? '#000' : 'var(--dim)', border: `1px solid ${colSize === l ? NOTES_COLOR : 'var(--brd)'}`, cursor: 'pointer' }}>{l}</button>
+          ))}
+        </div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.08em', color: NOTES_COLOR }}>📝 Journal</div>
+        <button className="btn btn-primary btn-sm" style={{ background: NOTES_COLOR, color: '#000' }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ New Note</button>
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flexDirection: isMobile ? 'column' : 'row' }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="tbar" style={{ padding: '0 0 8px' }}>
+            <input className="sx" placeholder="Search notes..." value={search} onChange={e => setSearch(e.target.value)} />
+          </div>
+
+          <div style={{ display: 'flex', gap: 3, flexWrap: 'wrap', marginBottom: 10 }}>
+            <button className={`fp ${catFilter === 'all' ? 'active' : ''}`} style={{ color: '#ff6b6b' }} onClick={() => setCatFilter('all')}>All</button>
+            {usedCats.map(c => (
+              <button key={c} className={`fp ${catFilter === c ? 'active' : ''}`} style={{ color: '#ff6b6b' }} onClick={() => setCatFilter(c)}>{c}</button>
+            ))}
+          </div>
+
+          {!filtered.length && (
+            <div className="empty">
+              <div className="empty-icon">📝</div>
+              <p>No notes yet.</p>
+              <p style={{ fontSize: '0.85em', color: 'var(--mut)', maxWidth: 300, margin: '8px auto' }}>For quick notes, brainstorms, canon reminders, research snippets, and anything that doesn't fit elsewhere.</p>
+              <button className="btn btn-primary" style={{ background: '#ff6b6b', color: '#000' }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add Note</button>
+            </div>
+          )}
+
+          <div style={{ display: 'grid', gridTemplateColumns: SIZE_COLS_N[colSize] > 1 ? `repeat(${SIZE_COLS_N[colSize]}, minmax(0,1fr))` : '1fr', gap: 6 }}>
+            {filtered.map((n, i) => (
+              <div
+                key={n.id}
+                id={`gcomp-entry-${n.id}`}
+                className="entry-card"
+                style={{ '--card-color': 'var(--cw)', background: i % 2 === 1 ? 'rgba(255,255,255,.01)' : undefined, cursor: 'pointer' }}
+                onClick={() => setViewNote(n)}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                  {n.title && <div className="entry-title" style={{ fontSize: '1em' }}>{n.title}</div>}
+                  {n.category && <span className="badge" style={{ color: '#ff6b6b', borderColor: 'rgba(255,204,0,.3)', flexShrink: 0, marginLeft: 8 }}>{n.category}</span>}
+                </div>
+                <div style={{ fontSize: '0.92em', color: 'var(--dim)', lineHeight: 1.5, marginTop: 4, whiteSpace: 'pre-wrap' }}>
+                  {n.content?.length > 300 ? n.content.slice(0, 300) + '...' : n.content}
+                </div>
+                <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 6 }}>
+                  {n.updated ? new Date(n.updated).toLocaleString() : ''}
+                </div>
+                <div className="entry-actions">
+                  <button className="btn btn-sm btn-outline" style={{ color: '#ff6b6b', borderColor: '#ff6b6b' }} onClick={e => { e.stopPropagation(); setEditing(n); setModalOpen(true) }}>✎ Edit</button>
+                  <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544' }} onClick={e => { e.stopPropagation(); setConfirmId(n.id) }}>✕</button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ width: isMobile ? '100%' : 240, flexShrink: 0 }}>
+          <div style={{ background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 10, padding: 10 }}>
+            <div style={{ fontSize: '1.1em', color: NOTES_COLOR, marginBottom: 8, textAlign: 'center' }}>📌</div>
+            {!pinnedStickies.length && (
+              <div style={{ fontSize: '0.8em', color: 'var(--mut)', fontStyle: 'italic' }}>No pinned stickies. Pin from the Stickies sub-tab.</div>
+            )}
+            {pinnedStickies.map(sticky => {
+              const sc = STICKY_COLORS.find(c => c.id === sticky.color) || STICKY_COLORS[0]
+              return (
+                <div
+                  key={sticky.id}
+                  draggable
+                  onDragStart={() => setDragId(sticky.id)}
+                  onDragOver={e => e.preventDefault()}
+                  onDrop={() => handleSidebarDrop(sticky.id)}
+                  style={{ padding: '8px 10px', borderRadius: 8, background: 'var(--sf)', border: '1px solid var(--brd)', marginBottom: 6 }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+                    <span style={{ width: 10, height: 10, borderRadius: '50%', background: sticky.customBg || sc.border, marginTop: 4, flexShrink: 0 }} />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: '0.8em', color: 'var(--tx)', lineHeight: 1.4, display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+                        {sticky.text}
+                      </div>
+                    </div>
+                    <button className="btn btn-sm btn-outline" onClick={() => setSidebarEdit(sticky)}>✎</button>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </div>
+
+      {viewNote && (
+        <div className="modal-overlay open" onClick={() => setViewNote(null)}>
+          <div className="modal-box" onClick={e => e.stopPropagation()} style={{ maxWidth: 640 }}>
+            <button className="modal-close" onClick={() => setViewNote(null)}>✕</button>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 10, flexWrap: 'wrap', gap: 8 }}>
+              {viewNote.title && <div className="modal-title" style={{ color: NOTES_COLOR }}>{viewNote.title}</div>}
+              {viewNote.category && <span className="badge" style={{ color: NOTES_COLOR, borderColor: 'rgba(255,204,0,.3)' }}>{viewNote.category}</span>}
+            </div>
+            <div style={{ fontSize: '0.92em', color: 'var(--tx)', lineHeight: 1.6, whiteSpace: 'pre-wrap', marginBottom: 12 }}>{viewNote.content}</div>
+            <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginBottom: 12 }}>
+              {viewNote.updated ? new Date(viewNote.updated).toLocaleString() : ''}
+            </div>
+            <div className="modal-actions">
+              <button className="btn btn-outline" onClick={() => { setViewNote(null); setEditing(viewNote); setModalOpen(true) }}>✎ Edit</button>
+              <button className="btn btn-outline" onClick={() => setViewNote(null)}>Close</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <Modal open={modalOpen} onClose={() => { setModalOpen(false); setEditing(null) }} title={editing?.id ? 'Edit Note' : 'Add Note'} color="var(--cw)">
+        {(editing !== null) && <NoteForm note={editing} onSave={handleSave} onCancel={() => { setModalOpen(false); setEditing(null) }} cats={NOTE_CATS} />}
+      </Modal>
+
+      <StickyEditModal
+        open={!!sidebarEdit}
+        sticky={sidebarEdit}
+        tags={[]}
+        onSave={saveSticky}
+        onClose={() => setSidebarEdit(null)}
+        showJournalUnpin
+      />
+
+      {confirmId && (
+        <div className="confirm-overlay open">
+          <div className="confirm-box">
+            <p>Delete this note?</p>
+            <button className="btn btn-outline btn-sm" onClick={() => setConfirmId(null)}>Cancel</button>{' '}
+            <button className="btn btn-danger btn-sm" onClick={() => { db.deleteEntry('notes', confirmId); setConfirmId(null); setViewNote(null) }}>Delete</button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/tabs/notes/StickiesView.jsx
+++ b/src/tabs/notes/StickiesView.jsx
@@ -1,0 +1,788 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { uid } from '../../constants'
+import { supabase, hasSupabase } from '../../supabase'
+import StickyEditModal from './StickyEditModal'
+import {
+  DEFAULT_TAGS,
+  IDEAS_CATEGORIES,
+  IDEAS_LS_KEY,
+  NOTES_COLOR,
+  STICKY_COLORS,
+  importNoteText,
+  lsGet,
+  lsSet,
+  normalizeSticky,
+  scrollAndFlashEntry,
+  sortStickies,
+  stickyTilt,
+  stickyTitle,
+} from './stickyShared'
+
+const JOURNAL_COLOR = '#38b000'
+
+const SEND_GROUPS = [
+  { label: 'STORY', items: [['characters', 'Characters'], ['locations', 'Locations'], ['items', 'Items'], ['scenes', 'Scenes'], ['timeline', 'Timeline']] },
+  { label: 'LORE', items: [['wiki', 'Wiki'], ['world', 'World'], ['glossary', 'Glossary']] },
+  { label: 'REFERENCE', items: [['spellings', 'Spellings'], ['canon', 'Canon']] },
+  { label: 'TRACKING', items: [['flags', 'Flags'], ['questions', 'Questions'], ['journal', 'Journal']] },
+]
+
+function QuickCapture({ tags, onAddSticky, onOpenLongForm }) {
+  const [text, setText] = useState('')
+  const [tag, setTag] = useState('unsorted')
+  const [color, setColor] = useState('yellow')
+  const [quickMode, setQuickMode] = useState('longform')
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuRef = useRef(null)
+
+  useEffect(() => {
+    function onDocClick(e) {
+      if (!menuRef.current?.contains(e.target)) setMenuOpen(false)
+    }
+    if (menuOpen) document.addEventListener('mousedown', onDocClick)
+    return () => document.removeEventListener('mousedown', onDocClick)
+  }, [menuOpen])
+
+  function submitSticky() {
+    if (!text.trim()) return
+    onAddSticky({ text: text.trim(), tag, color, size: 'normal', pinned_stickies: false, pinned_journal: false })
+    setText('')
+  }
+
+  function submitQuickCapture() {
+    if (!text.trim()) return
+    if (quickMode === 'sticky') submitSticky()
+    else {
+      onOpenLongForm(text.trim())
+      setText('')
+    }
+  }
+
+  function selectMode(mode) {
+    setQuickMode(mode)
+    setMenuOpen(false)
+  }
+
+  function handleCtrlQ(e) {
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'q') {
+      e.preventDefault()
+      submitQuickCapture()
+    }
+  }
+
+  const quickLabel = quickMode === 'sticky' ? '📌 Sticky' : '📝 Long-form note'
+
+  return (
+    <div style={{ background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 'var(--rl)', padding: 12, marginBottom: 12 }}>
+      <div style={{ fontFamily: "'Cinzel',serif", fontSize: '0.92em', color: JOURNAL_COLOR, marginBottom: 8 }}>✦ Quick Capture</div>
+      <textarea
+        value={text}
+        onChange={e => setText(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) submitQuickCapture()
+          handleCtrlQ(e)
+        }}
+        placeholder="Capture a thought, name, idea..."
+        style={{ width: '100%', minHeight: 70, padding: '6px 8px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 'var(--r)', color: 'var(--tx)', fontSize: '0.92em', resize: 'vertical', outline: 'none', fontFamily: 'inherit', boxSizing: 'border-box' }}
+      />
+      <div style={{ display: 'flex', gap: 6, marginTop: 6, flexWrap: 'wrap', alignItems: 'center' }}>
+        <select value={tag} onChange={e => setTag(e.target.value)} style={{ fontSize: '0.77em', padding: '3px 6px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', flex: 1, minWidth: 80 }}>
+          {tags.map(t => <option key={t.id} value={t.id}>{t.label}</option>)}
+        </select>
+        <select value={color} onChange={e => setColor(e.target.value)} style={{ fontSize: '0.77em', padding: '3px 6px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', flex: 1, minWidth: 80 }}>
+          {STICKY_COLORS.map(c => <option key={c.id} value={c.id}>{c.label}</option>)}
+        </select>
+        <button className="btn btn-sm btn-outline" style={{ flexShrink: 0 }} onClick={submitSticky}>Save Sticky</button>
+        <div ref={menuRef} style={{ display: 'flex', position: 'relative', flexShrink: 0 }}>
+          <button className="btn btn-sm" style={{ background: JOURNAL_COLOR, color: '#000', borderTopRightRadius: 0, borderBottomRightRadius: 0 }} onClick={submitQuickCapture} title="Quick Capture (Ctrl+Q)">
+            {quickLabel}
+          </button>
+          <button className="btn btn-sm" style={{ background: JOURNAL_COLOR, color: '#000', borderTopLeftRadius: 0, borderBottomLeftRadius: 0, borderLeft: '1px solid rgba(0,0,0,.2)', paddingInline: 8 }} onClick={() => setMenuOpen(o => !o)} aria-label="Quick capture options">
+            ▾
+          </button>
+          {menuOpen && (
+            <div style={{ position: 'absolute', right: 0, top: '100%', marginTop: 4, background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 8, overflow: 'hidden', zIndex: 20, minWidth: 160 }}>
+              <button onClick={() => selectMode('longform')} style={{ width: '100%', textAlign: 'left', padding: '6px 8px', fontSize: '0.77em', background: quickMode === 'longform' ? 'rgba(56,176,0,.15)' : 'none', border: 'none', color: 'var(--tx)', cursor: 'pointer' }}>📝 Long-form note</button>
+              <button onClick={() => selectMode('sticky')} style={{ width: '100%', textAlign: 'left', padding: '6px 8px', fontSize: '0.77em', background: quickMode === 'sticky' ? 'rgba(56,176,0,.15)' : 'none', border: 'none', color: 'var(--tx)', cursor: 'pointer' }}>📌 Sticky</button>
+            </div>
+          )}
+        </div>
+        <span style={{ fontSize: '0.62em', color: 'var(--mut)', marginLeft: 'auto' }}>Ctrl+Q</span>
+      </div>
+    </div>
+  )
+}
+
+function IdeasPanel({ ideas, setIdeas }) {
+  const [open, setOpen] = useState(false)
+  const [drafts, setDrafts] = useState({ names: '', words: '', phrases: '' })
+
+  useEffect(() => { lsSet(IDEAS_LS_KEY, ideas) }, [ideas])
+
+  useEffect(() => {
+    let ignore = false
+    async function loadIdeas() {
+      if (!hasSupabase || !supabase) return
+      try {
+        const { data, error } = await supabase.from('ideas_list').select('id, category, value, created_at').order('created_at', { ascending: false })
+        if (error || !data || ignore) return
+        setIdeas(data)
+      } catch {}
+    }
+    loadIdeas()
+    return () => { ignore = true }
+  }, [setIdeas])
+
+  async function addIdea(category) {
+    const value = (drafts[category] || '').trim()
+    if (!value) return
+    const idea = { id: uid(), category, value, created_at: new Date().toISOString() }
+    setIdeas(prev => [idea, ...prev])
+    setDrafts(prev => ({ ...prev, [category]: '' }))
+    if (!hasSupabase || !supabase) return
+    try { await supabase.from('ideas_list').insert(idea) } catch {}
+  }
+
+  async function removeIdea(id) {
+    setIdeas(prev => prev.filter(i => i.id !== id))
+    if (!hasSupabase || !supabase) return
+    try { await supabase.from('ideas_list').delete().eq('id', id) } catch {}
+  }
+
+  return (
+    <div style={{ background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 'var(--rl)', padding: 10, marginBottom: 12 }}>
+      <button className="btn btn-sm btn-outline" onClick={() => setOpen(o => !o)} style={{ width: '100%', justifyContent: 'space-between', display: 'flex', alignItems: 'center' }}>
+        <span>💡 Ideas</span>
+        <span>{open ? '▾' : '▸'}</span>
+      </button>
+      {open && (
+        <div style={{ marginTop: 8, display: 'grid', gap: 8 }}>
+          {IDEAS_CATEGORIES.map(cat => {
+            const catIdeas = ideas.filter(i => i.category === cat.id)
+            return (
+              <div key={cat.id}>
+                <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginBottom: 4 }}>{cat.label}</div>
+                <div style={{ display: 'flex', gap: 4 }}>
+                  <input className="sx" placeholder={`Add ${cat.label.toLowerCase()}...`} value={drafts[cat.id]} onChange={e => setDrafts(prev => ({ ...prev, [cat.id]: e.target.value }))} onKeyDown={e => { if (e.key === 'Enter') addIdea(cat.id) }} style={{ fontSize: '0.77em' }} />
+                  <button className="btn btn-sm" style={{ background: JOURNAL_COLOR, color: '#000' }} onClick={() => addIdea(cat.id)}>Add</button>
+                </div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 4 }}>
+                  {catIdeas.map(idea => (
+                    <span key={idea.id} style={{ fontSize: '0.69em', padding: '2px 6px', borderRadius: 999, border: '1px solid var(--brd)', background: 'var(--sf)', color: 'var(--tx)', display: 'inline-flex', gap: 4, alignItems: 'center' }}>
+                      {idea.value}
+                      <button onClick={() => removeIdea(idea.id)} style={{ border: 'none', background: 'none', color: 'var(--mut)', cursor: 'pointer', fontSize: '0.85em', padding: 0 }}>✕</button>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function LongFormNoteModal({ open, draft, setDraft, onClose, onSave }) {
+  if (!open) return null
+  return (
+    <div className="modal-overlay open" onClick={onClose}>
+      <div className="modal-box" onClick={e => e.stopPropagation()} style={{ maxWidth: 560 }}>
+        <button className="modal-close" onClick={onClose}>✕</button>
+        <div className="modal-title" style={{ color: JOURNAL_COLOR }}>📝 New Long-form Note</div>
+        <div className="field">
+          <label>Title (optional)</label>
+          <input value={draft.title} onChange={e => setDraft(prev => ({ ...prev, title: e.target.value }))} placeholder="Note title..." />
+        </div>
+        <div className="field">
+          <label>Category</label>
+          <select value={draft.category} onChange={e => setDraft(prev => ({ ...prev, category: e.target.value }))}>
+            <option value="General">General</option>
+            <option value="Canon">Canon</option>
+            <option value="Brainstorm">Brainstorm</option>
+            <option value="Research">Research</option>
+            <option value="Todo">Todo</option>
+            <option value="Quote">Quote</option>
+            <option value="Other">Other</option>
+          </select>
+        </div>
+        <div className="field">
+          <label>Content</label>
+          <textarea value={draft.content} onChange={e => setDraft(prev => ({ ...prev, content: e.target.value }))} placeholder="Write your long-form note..." style={{ minHeight: 160 }} />
+        </div>
+        <div className="modal-actions">
+          <button className="btn btn-outline" onClick={onClose}>Cancel</button>
+          <button className="btn btn-primary" style={{ background: JOURNAL_COLOR, color: '#000' }} onClick={onSave}>Save Note</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function TagManager({ tags, onUpdate, onClose }) {
+  const [localTags, setLocalTags] = useState(tags)
+  const [newLabel, setNewLabel] = useState('')
+  const [newColor, setNewColor] = useState('#cc66ff')
+
+  function addTag() {
+    if (!newLabel.trim()) return
+    const t = { id: uid(), label: newLabel.trim(), color: newColor }
+    setLocalTags(prev => [...prev, t])
+    setNewLabel('')
+  }
+
+  function updateTag(id, field, val) {
+    setLocalTags(prev => prev.map(t => t.id === id ? { ...t, [field]: val } : t))
+  }
+
+  function removeTag(id) {
+    if (id === 'unsorted') return
+    setLocalTags(prev => prev.filter(t => t.id !== id))
+  }
+
+  return (
+    <div>
+      {localTags.map(t => (
+        <div key={t.id} style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 6 }}>
+          <input type="color" value={t.color} onChange={e => updateTag(t.id, 'color', e.target.value)} style={{ width: 24, height: 24, padding: 0, border: 'none', borderRadius: 4, cursor: 'pointer' }} />
+          <input value={t.label} onChange={e => updateTag(t.id, 'label', e.target.value)} style={{ flex: 1, padding: '4px 8px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', fontSize: '0.85em' }} />
+          {t.id !== 'unsorted' && (
+            <button onClick={() => removeTag(t.id)} style={{ background: 'none', border: 'none', color: '#ff3355', cursor: 'pointer', fontSize: '1em', padding: '0 2px' }}>✕</button>
+          )}
+        </div>
+      ))}
+      <div style={{ display: 'flex', gap: 6, marginTop: 10, alignItems: 'center' }}>
+        <input type="color" value={newColor} onChange={e => setNewColor(e.target.value)} style={{ width: 24, height: 24, padding: 0, border: 'none', borderRadius: 4, cursor: 'pointer' }} />
+        <input value={newLabel} onChange={e => setNewLabel(e.target.value)} placeholder="New tag name..." onKeyDown={e => e.key === 'Enter' && addTag()} style={{ flex: 1, padding: '4px 8px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', fontSize: '0.85em' }} />
+        <button className="btn btn-sm" style={{ background: JOURNAL_COLOR, color: '#000' }} onClick={addTag}>+ Add</button>
+      </div>
+      <div className="modal-actions" style={{ marginTop: 14 }}>
+        <button className="btn btn-outline" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary" style={{ background: JOURNAL_COLOR, color: '#000' }} onClick={() => { onUpdate(localTags); onClose() }}>Save Tags</button>
+      </div>
+    </div>
+  )
+}
+
+function SendToMenu({ sticky, onSend }) {
+  return (
+    <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, zIndex: 30, background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 8, padding: 8, minWidth: 220, boxShadow: '0 4px 16px rgba(0,0,0,.18)' }}>
+      {SEND_GROUPS.map(group => (
+        <div key={group.label} style={{ marginBottom: 8 }}>
+          <div style={{ fontSize: '0.62em', color: 'var(--mut)', letterSpacing: '.08em', textTransform: 'uppercase', marginBottom: 4 }}>{group.label}</div>
+          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+            {group.items.map(([value, label]) => (
+              <button key={value} onClick={() => onSend(sticky, value)} style={{ fontSize: '0.69em', padding: '3px 8px', borderRadius: 999, border: '1px solid var(--brd)', background: 'var(--sf)', color: 'var(--tx)', cursor: 'pointer' }}>
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function StickyBoard({
+  captures, tags, onDelete, onEdit, onReorder, onSendTo, crossLink,
+  showArchived, archivedOnly,
+}) {
+  const [sortMode, setSortMode] = useState('manual')
+  const [searchQ, setSearchQ] = useState('')
+  const [filterTag, setFilterTag] = useState('all')
+  const [filterColor, setFilterColor] = useState('all')
+  const [todayOnly, setTodayOnly] = useState(false)
+  const [editId, setEditId] = useState(null)
+  const [controlsOpen, setControlsOpen] = useState(new Set())
+  const [editText, setEditText] = useState('')
+  const [dragSource, setDragSource] = useState(null)
+  const [presetName, setPresetName] = useState('')
+  const [showPresetInput, setShowPresetInput] = useState(false)
+  const [presets, setPresets] = useState(() => lsGet('journal_presets', []))
+  const [sendOpenId, setSendOpenId] = useState(null)
+  const sendMenuRef = useRef(null)
+
+  useEffect(() => {
+    function onDocClick(e) {
+      if (!sendMenuRef.current?.contains(e.target)) setSendOpenId(null)
+    }
+    if (sendOpenId) document.addEventListener('mousedown', onDocClick)
+    return () => document.removeEventListener('mousedown', onDocClick)
+  }, [sendOpenId])
+
+  const today = new Date().toDateString()
+
+  function toggleControls(id) {
+    setControlsOpen(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const filtered = captures
+    .filter(c => {
+      if (searchQ && !c.text?.toLowerCase().includes(searchQ.toLowerCase())) return false
+      if (filterTag !== 'all' && c.tag !== filterTag) return false
+      if (filterColor !== 'all' && c.color !== filterColor) return false
+      if (todayOnly && new Date(c.created).toDateString() !== today) return false
+      if (archivedOnly) return !!c.archived
+      if (!showArchived && c.archived) return false
+      return true
+    })
+    .sort((a, b) => {
+      if (sortMode === 'manual') return 0
+      if (sortMode === 'newest') return new Date(b.created) - new Date(a.created)
+      if (sortMode === 'oldest') return new Date(a.created) - new Date(b.created)
+      if (sortMode === 'alpha') return (a.text || '').localeCompare(b.text || '')
+      if (sortMode === 'pinned') return (b.pinned_stickies ? 1 : 0) - (a.pinned_stickies ? 1 : 0)
+      if (sortMode === 'tag') return (a.tag || '').localeCompare(b.tag || '')
+      return 0
+    })
+
+  const displayed = sortMode === 'manual'
+    ? sortStickies(filtered)
+    : filtered
+
+  function handleDrop(target) {
+    if (!dragSource || dragSource.id === target.id || sortMode !== 'manual') return
+    if (!!dragSource.pinned_stickies !== !!target.pinned_stickies) return
+    const group = displayed.filter(c => !!c.pinned_stickies === !!target.pinned_stickies && !c.archived)
+    const from = group.findIndex(c => c.id === dragSource.id)
+    const to = group.findIndex(c => c.id === target.id)
+    if (from < 0 || to < 0) return
+    const reordered = [...group]
+    const [moved] = reordered.splice(from, 1)
+    reordered.splice(to, 0, moved)
+    const updates = reordered.map((sticky, idx) => ({ ...sticky, sort_order: idx }))
+    onReorder(updates, !!target.pinned_stickies)
+    setDragSource(null)
+  }
+
+  function startEdit(c) {
+    setEditId(c.id)
+    setEditText(c.text || '')
+    toggleControls(c.id)
+  }
+
+  function saveEdit(c) {
+    if (editText.trim()) onEdit({ ...c, text: editText.trim() })
+    setEditId(null)
+  }
+
+  function savePreset() {
+    if (!presetName.trim()) return
+    const preset = { name: presetName.trim(), sortMode, filterTag, filterColor, todayOnly }
+    const updated = [...presets, preset]
+    setPresets(updated)
+    lsSet('journal_presets', updated)
+    setPresetName('')
+    setShowPresetInput(false)
+  }
+
+  function applyPreset(p) {
+    setSortMode(p.sortMode)
+    setFilterTag(p.filterTag)
+    setFilterColor(p.filterColor)
+    setTodayOnly(p.todayOnly)
+  }
+
+  function deletePreset(i) {
+    const updated = presets.filter((_, pi) => pi !== i)
+    setPresets(updated)
+    lsSet('journal_presets', updated)
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 8, alignItems: 'center' }}>
+        <input className="sx" placeholder="Search stickies..." value={searchQ} onChange={e => setSearchQ(e.target.value)} style={{ flex: 1, minWidth: 140 }} />
+        <select value={sortMode} onChange={e => setSortMode(e.target.value)} style={{ fontSize: '0.77em', padding: '3px 6px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
+          <option value="manual">Manual order</option>
+          <option value="newest">Newest first</option>
+          <option value="oldest">Oldest first</option>
+          <option value="alpha">A - Z</option>
+          <option value="pinned">Pinned first</option>
+          <option value="tag">By tag</option>
+        </select>
+        <select value={filterTag} onChange={e => setFilterTag(e.target.value)} style={{ fontSize: '0.77em', padding: '3px 6px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
+          <option value="all">All tags</option>
+          {tags.map(t => <option key={t.id} value={t.id}>{t.label}</option>)}
+        </select>
+        <select value={filterColor} onChange={e => setFilterColor(e.target.value)} style={{ fontSize: '0.77em', padding: '3px 6px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
+          <option value="all">All colors</option>
+          {STICKY_COLORS.map(c => <option key={c.id} value={c.id}>{c.label}</option>)}
+        </select>
+        <button className="btn btn-sm btn-outline" style={todayOnly ? { color: JOURNAL_COLOR, borderColor: JOURNAL_COLOR } : {}} onClick={() => setTodayOnly(t => !t)}>Today</button>
+      </div>
+
+      {(presets.length > 0 || showPresetInput) && (
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 8, alignItems: 'center' }}>
+          {presets.map((p, i) => (
+            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              <button onClick={() => applyPreset(p)} style={{ fontSize: '0.62em', padding: '2px 8px', borderRadius: 10, border: `1px solid ${JOURNAL_COLOR}`, background: 'none', color: JOURNAL_COLOR, cursor: 'pointer' }}>{p.name}</button>
+              <button onClick={() => deletePreset(i)} style={{ fontSize: '0.62em', background: 'none', border: 'none', color: 'var(--mut)', cursor: 'pointer' }}>✕</button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+        <div style={{ fontSize: '0.69em', color: 'var(--mut)' }}>
+          {displayed.length} of {captures.length} stickies
+          {sortMode === 'manual' && ' - drag to reorder'}
+        </div>
+        {!showPresetInput
+          ? <button onClick={() => setShowPresetInput(true)} style={{ fontSize: '0.62em', padding: '2px 7px', borderRadius: 6, border: '1px solid var(--brd)', background: 'none', color: 'var(--mut)', cursor: 'pointer' }}>+ Save view</button>
+          : <div style={{ display: 'flex', gap: 4 }}>
+              <input value={presetName} onChange={e => setPresetName(e.target.value)} onKeyDown={e => e.key === 'Enter' && savePreset()} placeholder="Preset name..." autoFocus style={{ fontSize: '0.69em', padding: '2px 6px', borderRadius: 6, border: '1px solid var(--brd)', background: 'var(--sf)', color: 'var(--tx)', width: 100 }} />
+              <button onClick={savePreset} style={{ fontSize: '0.62em', padding: '2px 7px', borderRadius: 6, border: 'none', background: JOURNAL_COLOR, color: '#000', cursor: 'pointer' }}>Save</button>
+              <button onClick={() => setShowPresetInput(false)} style={{ fontSize: '0.62em', padding: '2px 6px', borderRadius: 6, border: '1px solid var(--brd)', background: 'none', color: 'var(--mut)', cursor: 'pointer' }}>✕</button>
+            </div>
+        }
+      </div>
+
+      {!displayed.length && (
+        <div className="empty">
+          <div className="empty-icon">📌</div>
+          <p>{captures.length > 0 ? 'No stickies match your filter.' : 'No stickies yet. Use Quick Capture to add your first!'}</p>
+        </div>
+      )}
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, alignItems: 'flex-start' }}>
+        {displayed.map(c => {
+          const sc = STICKY_COLORS.find(x => x.id === c.color) || STICKY_COLORS[0]
+          const tag = tags.find(t => t.id === c.tag) || DEFAULT_TAGS[DEFAULT_TAGS.length - 1]
+          const tilt = stickyTilt(c.id)
+          const isEditing = editId === c.id
+          const size = c.size || 'normal'
+          const width = size === 'small' ? 140 : size === 'large' ? 260 : size === 'xl' ? 340 : 190
+          const bgColor = c.customBg || sc.bg
+          const textColor = c.customText || sc.text
+          const fontSize = c.fontSize || '0.92em'
+          const archivedDim = c.archived && !archivedOnly
+
+          return (
+            <div
+              key={c.id}
+              id={`gcomp-entry-${c.id}`}
+              draggable={sortMode === 'manual' && !c.archived}
+              onDragStart={() => setDragSource(c)}
+              onDragOver={e => e.preventDefault()}
+              onDrop={() => handleDrop(c)}
+              style={{
+                width,
+                minHeight: size === 'small' ? 100 : size === 'large' ? 180 : size === 'xl' ? 240 : 140,
+                background: bgColor,
+                border: `1px solid ${c.customBorder || sc.border}`,
+                borderRadius: 4,
+                boxShadow: '2px 3px 8px rgba(0,0,0,.15)',
+                padding: size === 'small' ? 8 : 12,
+                transform: `rotate(${tilt}deg)`,
+                transition: 'transform .15s, box-shadow .15s',
+                position: 'relative',
+                cursor: sortMode === 'manual' && !c.archived ? 'grab' : 'default',
+                flexShrink: 0,
+                boxSizing: 'border-box',
+                opacity: archivedOnly ? 1 : archivedDim ? 0.5 : 1,
+              }}
+              onMouseEnter={e => { e.currentTarget.style.transform = 'rotate(0deg) scale(1.02)'; e.currentTarget.style.boxShadow = '4px 6px 16px rgba(0,0,0,.22)'; e.currentTarget.style.zIndex = 10 }}
+              onMouseLeave={e => { e.currentTarget.style.transform = `rotate(${tilt}deg)`; e.currentTarget.style.boxShadow = '2px 3px 8px rgba(0,0,0,.15)'; e.currentTarget.style.zIndex = 1 }}
+            >
+              <div style={{ position: 'absolute', top: 0, right: 0, width: 0, height: 0, borderStyle: 'solid', borderWidth: '0 18px 18px 0', borderColor: `transparent ${tag.color}55 transparent transparent` }} title={tag.label} />
+              {(c.pinned_stickies || c.pinned) && <div style={{ position: 'absolute', top: -8, left: '50%', transform: 'translateX(-50%)', fontSize: '0.92em' }}>📌</div>}
+
+              {isEditing ? (
+                <div>
+                  <textarea value={editText} onChange={e => setEditText(e.target.value)} autoFocus style={{ width: '100%', minHeight: 60, background: 'rgba(255,255,255,.6)', border: '1px solid rgba(0,0,0,.2)', borderRadius: 3, padding: '4px 6px', fontSize, color: textColor, resize: 'vertical', fontFamily: 'inherit', outline: 'none', boxSizing: 'border-box' }} />
+                  <div style={{ display: 'flex', gap: 4, marginTop: 4, flexWrap: 'wrap' }}>
+                    <button onClick={() => saveEdit(c)} style={{ fontSize: '0.62em', padding: '2px 7px', borderRadius: 4, border: 'none', background: sc.border, color: '#fff', cursor: 'pointer' }}>Save</button>
+                    <button onClick={() => setEditId(null)} style={{ fontSize: '0.62em', padding: '2px 6px', borderRadius: 4, border: `1px solid ${sc.border}`, background: 'none', color: textColor, cursor: 'pointer' }}>Cancel</button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div style={{ fontSize, color: textColor, lineHeight: 1.45, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{c.text}</div>
+                  <div style={{ fontSize: '0.62em', color: textColor, opacity: 0.6, marginTop: 6 }}>{c.created ? new Date(c.created).toLocaleString() : ''}</div>
+
+                  <div style={{ display: 'flex', gap: 4, marginTop: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+                    <button onClick={() => { toggleControls(c.id); if (editId === c.id) setEditId(null) }} title={controlsOpen.has(c.id) ? 'Hide controls' : 'Edit / style'} style={{ fontSize: '0.62em', padding: '1px 6px', borderRadius: 4, border: `1px solid ${sc.border}`, background: controlsOpen.has(c.id) ? sc.border : 'none', color: controlsOpen.has(c.id) ? '#fff' : textColor, cursor: 'pointer' }}>✎</button>
+                    <button onClick={() => onEdit({ ...c, pinned_stickies: !c.pinned_stickies, pinned_journal: !c.pinned_stickies, pinned: undefined })} title={c.pinned_stickies ? 'Unpin' : 'Pin'} style={{ fontSize: '0.62em', padding: '1px 6px', borderRadius: 4, border: `1px solid ${sc.border}`, background: c.pinned_stickies ? sc.border : 'none', color: c.pinned_stickies ? '#fff' : textColor, cursor: 'pointer' }}>📌</button>
+                    {!c.archived && (
+                      <div ref={sendOpenId === c.id ? sendMenuRef : null} style={{ position: 'relative' }}>
+                        <button onClick={() => setSendOpenId(sendOpenId === c.id ? null : c.id)} style={{ fontSize: '0.62em', padding: '1px 6px', borderRadius: 4, border: `1px solid ${sc.border}`, background: 'none', color: textColor, cursor: 'pointer' }}>Send to ▾</button>
+                        {sendOpenId === c.id && <SendToMenu sticky={c} onSend={(sticky, target) => { onSendTo(sticky, target); setSendOpenId(null) }} />}
+                      </div>
+                    )}
+                    <button onClick={() => onDelete(c.id)} title="Delete" style={{ fontSize: '0.62em', padding: '1px 6px', borderRadius: 4, border: '1px solid rgba(255,0,0,.3)', background: 'none', color: '#cc0000', cursor: 'pointer' }}>✕</button>
+                  </div>
+
+                  <div style={{ fontSize: '0.62em', marginTop: 6, color: textColor, opacity: 0.8 }}>
+                    {c.archived
+                      ? (
+                        <button onClick={() => c.archived_destination && c.archived_destination_id && crossLink?.(c.archived_destination, c.archived_destination_id)} style={{ border: 'none', background: 'none', color: textColor, cursor: c.archived_destination ? 'pointer' : 'default', padding: 0, fontSize: 'inherit' }}>
+                          📦 → {c.archived_destination ? c.archived_destination[0].toUpperCase() + c.archived_destination.slice(1) : 'Archived'}
+                        </button>
+                        )
+                      : <span>Send to → Choose destination</span>
+                    }
+                  </div>
+
+                  {controlsOpen.has(c.id) && (
+                    <div style={{ display: 'flex', gap: 4, marginTop: 6, flexWrap: 'wrap', alignItems: 'center', padding: '6px', background: 'rgba(0,0,0,.08)', borderRadius: 4 }}>
+                      <select value={c.color || 'yellow'} onChange={e => onEdit({ ...c, color: e.target.value })} title="Preset color" style={{ fontSize: '0.62em', padding: '1px 3px', background: 'rgba(255,255,255,.5)', border: `1px solid ${sc.border}`, borderRadius: 4, color: textColor, maxWidth: 80 }}>
+                        {STICKY_COLORS.map(sc2 => <option key={sc2.id} value={sc2.id}>{sc2.label}</option>)}
+                      </select>
+                      <input type="color" value={c.customBg || sc.bg} title="Custom background" onChange={e => onEdit({ ...c, customBg: e.target.value })} style={{ width: 18, height: 18, padding: 0, border: 'none', borderRadius: 3, cursor: 'pointer' }} />
+                      <input type="color" value={c.customText || sc.text} title="Custom text color" onChange={e => onEdit({ ...c, customText: e.target.value })} style={{ width: 18, height: 18, padding: 0, border: 'none', borderRadius: 3, cursor: 'pointer' }} />
+                      <select value={c.fontSize || '0.92em'} onChange={e => onEdit({ ...c, fontSize: e.target.value })} title="Font size" style={{ fontSize: '0.62em', padding: '1px 3px', background: 'rgba(255,255,255,.5)', border: `1px solid ${sc.border}`, borderRadius: 4, color: textColor, maxWidth: 52 }}>
+                        <option value="0.69em">XS</option>
+                        <option value="0.77em">S</option>
+                        <option value="0.92em">M</option>
+                        <option value="1.08em">L</option>
+                        <option value="1.23em">XL</option>
+                      </select>
+                      <select value={c.size || 'normal'} onChange={e => onEdit({ ...c, size: e.target.value })} title="Card size" style={{ fontSize: '0.62em', padding: '1px 3px', background: 'rgba(255,255,255,.5)', border: `1px solid ${sc.border}`, borderRadius: 4, color: textColor, maxWidth: 60 }}>
+                        <option value="small">Small</option>
+                        <option value="normal">Normal</option>
+                        <option value="large">Large</option>
+                        <option value="xl">XL</option>
+                      </select>
+                      <select value={c.tag || 'unsorted'} onChange={e => onEdit({ ...c, tag: e.target.value })} title="Tag" style={{ fontSize: '0.62em', padding: '1px 3px', background: 'rgba(255,255,255,.5)', border: `1px solid ${sc.border}`, borderRadius: 4, color: textColor, flex: 1, minWidth: 60 }}>
+                        {tags.map(t => <option key={t.id} value={t.id}>{t.label}</option>)}
+                      </select>
+                      <button onClick={() => startEdit(c)} title="Edit text" style={{ fontSize: '0.62em', padding: '1px 6px', borderRadius: 4, border: `1px solid ${sc.border}`, background: 'none', color: textColor, cursor: 'pointer' }}>✎ text</button>
+                      <label style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: '0.62em', color: textColor }}>
+                        <input type="checkbox" checked={!!c.pinned_journal} onChange={e => onEdit({ ...c, pinned_journal: e.target.checked })} />
+                        📌 Also pin to Journal sidebar
+                      </label>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default function StickiesView({ db, pendingExpandId, clearPendingExpandId, crossLink }) {
+  const [tags, setTags] = useState(() => lsGet('gcomp_journal_tags', DEFAULT_TAGS))
+  const [captures, setCaptures] = useState(() => lsGet('gcomp_captures', []).map((c, i) => normalizeSticky(c, i)))
+  const [showTagManager, setShowTagManager] = useState(false)
+  const [mobileZone, setMobileZone] = useState('capture')
+  const [ideas, setIdeas] = useState(() => lsGet(IDEAS_LS_KEY, []))
+  const [longFormOpen, setLongFormOpen] = useState(false)
+  const [longFormDraft, setLongFormDraft] = useState({ title: '', category: 'Brainstorm', content: '' })
+  const [showArchived, setShowArchived] = useState(false)
+  const [archivedOnly, setArchivedOnly] = useState(false)
+  const [focusedSticky, setFocusedSticky] = useState(null)
+
+  useEffect(() => {
+    const dbCaptures = (db.db.journal_captures || []).map((c, i) => normalizeSticky(c, i))
+    if (!dbCaptures.length) return
+    setCaptures(prev => {
+      const merged = new Map(prev.map(item => [item.id, item]))
+      dbCaptures.forEach(item => merged.set(item.id, item))
+      const next = sortStickies([...merged.values()])
+      lsSet('gcomp_captures', next)
+      return next
+    })
+  }, [db.db.journal_captures])
+
+  useEffect(() => {
+    if (!pendingExpandId) return
+    const entry = captures.find(c => c.id === pendingExpandId)
+    if (!entry) return
+    setFocusedSticky(entry)
+    window.setTimeout(() => scrollAndFlashEntry(entry.id), 50)
+    clearPendingExpandId?.()
+  }, [pendingExpandId, captures, clearPendingExpandId])
+
+  function saveTags(nextTags) {
+    setTags(nextTags)
+    lsSet('gcomp_journal_tags', nextTags)
+  }
+
+  function saveCaptures(nextCaptures) {
+    setCaptures(nextCaptures)
+    lsSet('gcomp_captures', nextCaptures)
+  }
+
+  function addCapture(item) {
+    const entry = normalizeSticky({ id: uid(), ...item, created: new Date().toISOString() }, captures.length)
+    const updated = sortStickies([entry, ...captures])
+    saveCaptures(updated)
+    db.upsertEntry('journal_captures', entry)
+  }
+
+  function openLongForm(prefill = '') {
+    setLongFormDraft({ title: '', category: 'Brainstorm', content: prefill })
+    setLongFormOpen(true)
+  }
+
+  function saveLongForm() {
+    if (!longFormDraft.content.trim()) return
+    db.upsertEntry('notes', {
+      id: uid(),
+      title: longFormDraft.title?.trim() || '',
+      category: longFormDraft.category || 'Brainstorm',
+      content: longFormDraft.content.trim(),
+      updated: new Date().toISOString(),
+    })
+    setLongFormOpen(false)
+    setLongFormDraft({ title: '', category: 'Brainstorm', content: '' })
+  }
+
+  function deleteCapture(id) {
+    saveCaptures(captures.filter(c => c.id !== id))
+    db.deleteEntry('journal_captures', id)
+  }
+
+  function editCapture(updated) {
+    const normalized = normalizeSticky({ ...updated, updated_at: new Date().toISOString() })
+    const next = captures.map(c => c.id === updated.id ? normalized : c)
+    saveCaptures(next)
+    db.upsertEntry('journal_captures', normalized)
+    if (focusedSticky?.id === updated.id) setFocusedSticky(normalized)
+  }
+
+  function reorderCaptures(updatedGroup, pinnedState) {
+    const updatesById = new Map(updatedGroup.map(item => [item.id, item]))
+    const next = captures.map(c => {
+      const update = updatesById.get(c.id)
+      if (!update) return c
+      return { ...c, sort_order: update.sort_order, pinned_stickies: pinnedState }
+    })
+    saveCaptures(next)
+    updatedGroup.forEach(item => {
+      const current = captures.find(c => c.id === item.id)
+      if (current) db.upsertEntry('journal_captures', { ...current, sort_order: item.sort_order, pinned_stickies: pinnedState, updated_at: new Date().toISOString() })
+    })
+  }
+
+  function buildDestination(target, sticky) {
+    const now = new Date()
+    const note = importNoteText(now)
+    const baseTitle = stickyTitle(sticky.text)
+    const fullText = (sticky.text || '').trim()
+    const base = {
+      id: uid(),
+      auto_imported: true,
+      source: 'sticky',
+      source_sticky_id: sticky.id,
+      status: 'provisional',
+      updated: now.toISOString(),
+      created: now.toISOString(),
+    }
+    if (target === 'characters') return { category: 'characters', tab: 'characters', entry: { ...base, name: baseTitle, display_name: baseTitle, notes: `${fullText}\n\n${note}` } }
+    if (target === 'locations') return { category: 'locations', tab: 'locations', entry: { ...base, name: baseTitle, description: fullText, notes: note } }
+    if (target === 'items') return { category: 'items', tab: 'items', entry: { ...base, name: baseTitle, significance: fullText, detail: note } }
+    if (target === 'scenes') return { category: 'scenes', tab: 'scenes', entry: { ...base, name: baseTitle, summary: sticky.text.slice(0, 80), detail: fullText, notes: note } }
+    if (target === 'timeline') return { category: 'timeline', tab: 'timeline', entry: { ...base, name: baseTitle, detail: fullText, notes: note } }
+    if (target === 'wiki') return { category: 'wiki', tab: 'wiki', entry: { ...base, title: baseTitle, summary: fullText.slice(0, 150), category: 'Lore', blocks: [{ id: uid(), type: 'callout', content: note }, { id: uid(), type: 'text', content: fullText }] } }
+    if (target === 'world') return { category: 'world', tab: 'world', entry: { ...base, name: baseTitle, detail: fullText, notes: note } }
+    if (target === 'glossary') return { category: 'wiki', tab: 'glossary', entry: { ...base, title: baseTitle, summary: fullText.slice(0, 150), category: 'Lore', is_glossary: true, blocks: [{ id: uid(), type: 'callout', content: note }, { id: uid(), type: 'text', content: fullText }] } }
+    if (target === 'spellings') return { category: 'spellings', tab: 'spellings', entry: { ...base, name: baseTitle, word: baseTitle, detail: fullText, notes: note } }
+    if (target === 'canon') return { category: 'canon', tab: 'canon', entry: { ...base, name: baseTitle, text: fullText, detail: note } }
+    if (target === 'flags') return { category: 'flags', tab: 'flags', entry: { ...base, name: baseTitle, detail: fullText, notes: note, priority: 'low' } }
+    if (target === 'questions') return { category: 'questions', tab: 'questions', entry: { ...base, name: sticky.text.slice(0, 200), text: sticky.text.slice(0, 200), detail: fullText, notes: note, priority: 'Low' } }
+    return { category: 'notes', tab: 'notes', entry: { ...base, title: baseTitle, content: fullText, import_note: note, category: 'Brainstorm' } }
+  }
+
+  function sendStickyTo(sticky, target) {
+    const { category, tab, entry } = buildDestination(target, sticky)
+    db.upsertEntry(category, entry)
+    const archivedSticky = {
+      ...sticky,
+      archived: true,
+      archived_destination: tab,
+      archived_destination_id: entry.id,
+      archived_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    editCapture(archivedSticky)
+  }
+
+  const archivedCount = captures.filter(c => c.archived).length
+  const isMobile = typeof window !== 'undefined' ? window.innerWidth < 700 : false
+  const recentCaptures = sortStickies(captures).slice(0, 8)
+
+  return (
+    <div>
+      <div className="tbar">
+        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.08em', color: JOURNAL_COLOR }}>📌 Stickies</div>
+        {isMobile && (
+          <div style={{ display: 'flex', gap: 4 }}>
+            <button className="btn btn-sm" style={{ background: mobileZone === 'capture' ? JOURNAL_COLOR : 'none', color: mobileZone === 'capture' ? '#000' : 'var(--dim)', border: `1px solid ${JOURNAL_COLOR}` }} onClick={() => setMobileZone('capture')}>Capture</button>
+            <button className="btn btn-sm" style={{ background: mobileZone === 'stickies' ? JOURNAL_COLOR : 'none', color: mobileZone === 'stickies' ? '#000' : 'var(--dim)', border: `1px solid ${JOURNAL_COLOR}` }} onClick={() => setMobileZone('stickies')}>Stickies</button>
+          </div>
+        )}
+        <button className="btn btn-sm btn-outline" onClick={() => setShowTagManager(true)}>🏷 Tags</button>
+        <span style={{ fontSize: '0.69em', color: 'var(--mut)' }}>{captures.length} stickies</span>
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+        {(!isMobile || mobileZone === 'capture') && (
+          <div style={{ width: isMobile ? '100%' : 260, flexShrink: 0 }}>
+            <QuickCapture tags={tags} onAddSticky={addCapture} onOpenLongForm={openLongForm} />
+            <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
+              <button onClick={() => setShowArchived(v => !v)} style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 999, border: `1px solid ${showArchived ? NOTES_COLOR : 'var(--brd)'}`, background: showArchived ? '#ffcc0022' : 'none', color: showArchived ? NOTES_COLOR : 'var(--dim)', cursor: 'pointer' }}>
+                👁 Show archived ({archivedCount})
+              </button>
+              <button onClick={() => setArchivedOnly(v => !v)} style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 999, border: `1px solid ${archivedOnly ? NOTES_COLOR : 'var(--brd)'}`, background: archivedOnly ? '#ffcc0022' : 'none', color: archivedOnly ? NOTES_COLOR : 'var(--dim)', cursor: 'pointer' }}>
+                Archived only
+              </button>
+            </div>
+            <IdeasPanel ideas={ideas} setIdeas={setIdeas} />
+            <div style={{ fontSize: '0.77em', color: 'var(--mut)', marginBottom: 6 }}>Recent captures</div>
+            {recentCaptures.map(c => {
+              const sc = STICKY_COLORS.find(x => x.id === c.color) || STICKY_COLORS[0]
+              const tag = tags.find(t => t.id === c.tag)
+              return (
+                <div key={c.id} style={{ padding: '5px 8px', marginBottom: 4, background: `${sc.bg}cc`, border: `1px solid ${sc.border}44`, borderRadius: 6, fontSize: '0.77em', color: sc.text, position: 'relative', opacity: c.archived ? 0.6 : 1 }}>
+                  <div style={{ paddingRight: 16, lineHeight: 1.4 }}>{c.text?.slice(0, 80)}{(c.text?.length || 0) > 80 ? '...' : ''}</div>
+                  {tag && <div style={{ fontSize: '0.69em', color: tag.color, marginTop: 2 }}>{tag.label}</div>}
+                  <button onClick={() => deleteCapture(c.id)} style={{ position: 'absolute', top: 4, right: 4, background: 'none', border: 'none', color: sc.border, cursor: 'pointer', fontSize: '0.85em', padding: 0 }}>✕</button>
+                </div>
+              )
+            })}
+            {captures.length > 8 && <div style={{ fontSize: '0.69em', color: 'var(--mut)', textAlign: 'center', marginTop: 4 }}>+{captures.length - 8} more - view in Stickies →</div>}
+          </div>
+        )}
+
+        {(!isMobile || mobileZone === 'stickies') && (
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <StickyBoard
+              captures={captures}
+              tags={tags}
+              onDelete={deleteCapture}
+              onEdit={editCapture}
+              onReorder={reorderCaptures}
+              onSendTo={sendStickyTo}
+              crossLink={crossLink}
+              showArchived={showArchived}
+              archivedOnly={archivedOnly}
+            />
+          </div>
+        )}
+      </div>
+
+      {showTagManager && (
+        <div className="modal-overlay open" onClick={() => setShowTagManager(false)}>
+          <div className="modal-box" onClick={e => e.stopPropagation()} style={{ maxWidth: 440 }}>
+            <button className="modal-close" onClick={() => setShowTagManager(false)}>✕</button>
+            <div className="modal-title" style={{ color: JOURNAL_COLOR }}>🏷 Manage Tags</div>
+            <TagManager tags={tags} onUpdate={saveTags} onClose={() => setShowTagManager(false)} />
+          </div>
+        </div>
+      )}
+
+      <LongFormNoteModal open={longFormOpen} draft={longFormDraft} setDraft={setLongFormDraft} onClose={() => setLongFormOpen(false)} onSave={saveLongForm} />
+      <StickyEditModal open={!!focusedSticky} sticky={focusedSticky} tags={tags} onSave={editCapture} onClose={() => setFocusedSticky(null)} />
+    </div>
+  )
+}

--- a/src/tabs/notes/StickyEditModal.jsx
+++ b/src/tabs/notes/StickyEditModal.jsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react'
+import Modal from '../../components/common/Modal'
+import { DEFAULT_TAGS, STICKY_COLORS } from './stickyShared'
+
+export default function StickyEditModal({ open, sticky, tags, onSave, onClose, showJournalUnpin = false }) {
+  const [form, setForm] = useState(sticky || null)
+
+  useEffect(() => {
+    setForm(sticky || null)
+  }, [sticky])
+
+  if (!open || !form) return null
+
+  const tagList = tags?.length ? tags : DEFAULT_TAGS
+
+  function patch(next) {
+    setForm(prev => ({ ...prev, ...next }))
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title="Edit Sticky" color="#ffcc00">
+      <div className="field">
+        <label>Text</label>
+        <textarea
+          value={form.text || ''}
+          onChange={e => patch({ text: e.target.value })}
+          style={{ minHeight: 150 }}
+        />
+      </div>
+      <div className="field-row">
+        <div className="field">
+          <label>Tag</label>
+          <select value={form.tag || 'unsorted'} onChange={e => patch({ tag: e.target.value })}>
+            {tagList.map(t => <option key={t.id} value={t.id}>{t.label}</option>)}
+          </select>
+        </div>
+        <div className="field">
+          <label>Preset Color</label>
+          <select value={form.color || 'yellow'} onChange={e => patch({ color: e.target.value })}>
+            {STICKY_COLORS.map(c => <option key={c.id} value={c.id}>{c.label}</option>)}
+          </select>
+        </div>
+      </div>
+      <div className="field-row">
+        <div className="field">
+          <label>Custom Background</label>
+          <input type="color" value={form.customBg || '#fffde7'} onChange={e => patch({ customBg: e.target.value })} />
+        </div>
+        <div className="field">
+          <label>Custom Text</label>
+          <input type="color" value={form.customText || '#5d4037'} onChange={e => patch({ customText: e.target.value })} />
+        </div>
+      </div>
+      <div className="field-row">
+        <div className="field">
+          <label>Font Size</label>
+          <select value={form.fontSize || '0.92em'} onChange={e => patch({ fontSize: e.target.value })}>
+            <option value="0.69em">XS</option>
+            <option value="0.77em">S</option>
+            <option value="0.92em">M</option>
+            <option value="1.08em">L</option>
+            <option value="1.23em">XL</option>
+          </select>
+        </div>
+        <div className="field">
+          <label>Card Size</label>
+          <select value={form.size || 'normal'} onChange={e => patch({ size: e.target.value })}>
+            <option value="small">Small</option>
+            <option value="normal">Normal</option>
+            <option value="large">Large</option>
+            <option value="xl">XL</option>
+          </select>
+        </div>
+      </div>
+      <div style={{ display: 'grid', gap: 8, marginTop: 8 }}>
+        <label style={{ display: 'flex', gap: 8, alignItems: 'center', fontSize: '0.85em', color: 'var(--tx)' }}>
+          <input type="checkbox" checked={!!form.pinned_stickies} onChange={e => patch({ pinned_stickies: e.target.checked })} />
+          Pin to Stickies
+        </label>
+        <label style={{ display: 'flex', gap: 8, alignItems: 'center', fontSize: '0.85em', color: 'var(--tx)' }}>
+          <input type="checkbox" checked={!!form.pinned_journal} onChange={e => patch({ pinned_journal: e.target.checked })} />
+          Also pin to Journal sidebar
+        </label>
+        {showJournalUnpin && (
+          <button
+            className="btn btn-sm btn-outline"
+            style={{ justifySelf: 'flex-start' }}
+            onClick={() => patch({ pinned_journal: false })}
+          >
+            Unpin from Journal
+          </button>
+        )}
+      </div>
+      <div className="modal-actions">
+        <button className="btn btn-outline" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary" style={{ background: '#ffcc00', color: '#000' }} onClick={() => onSave(form)}>
+          Save Sticky
+        </button>
+      </div>
+    </Modal>
+  )
+}

--- a/src/tabs/notes/stickyShared.js
+++ b/src/tabs/notes/stickyShared.js
@@ -1,0 +1,106 @@
+export const NOTES_COLOR = '#ffcc00'
+
+export const STICKY_COLORS = [
+  { id: 'yellow', bg: '#fffde7', border: '#f9a825', text: '#5d4037', label: 'Yellow' },
+  { id: 'pink', bg: '#fce4ec', border: '#e91e63', text: '#880e4f', label: 'Pink' },
+  { id: 'mint', bg: '#e8f5e9', border: '#43a047', text: '#1b5e20', label: 'Mint' },
+  { id: 'lavender', bg: '#ede7f6', border: '#7e57c2', text: '#311b92', label: 'Lavender' },
+  { id: 'peach', bg: '#fff3e0', border: '#fb8c00', text: '#bf360c', label: 'Peach' },
+  { id: 'sky', bg: '#e3f2fd', border: '#1e88e5', text: '#0d47a1', label: 'Sky' },
+  { id: 'coral', bg: '#fbe9e7', border: '#e64a19', text: '#bf360c', label: 'Coral' },
+  { id: 'lilac', bg: '#f3e5f5', border: '#ab47bc', text: '#4a148c', label: 'Lilac' },
+]
+
+export const DEFAULT_TAGS = [
+  { id: 'name-person', label: 'Name - Person', color: '#c966ff' },
+  { id: 'name-place', label: 'Name - Place', color: '#3388ff' },
+  { id: 'name-thing', label: 'Name - Thing', color: '#00ccaa' },
+  { id: 'magic', label: 'Magic', color: '#ff44aa' },
+  { id: 'lore', label: 'Lore', color: '#ffaa33' },
+  { id: 'history', label: 'History', color: '#cc6644' },
+  { id: 'language', label: 'Language', color: '#00e5cc' },
+  { id: 'plot-idea', label: 'Plot Idea', color: '#ff3355' },
+  { id: 'vibe', label: 'Vibe / Mood', color: '#9933ff' },
+  { id: 'unsorted', label: 'Unsorted', color: '#666688' },
+]
+
+export const IDEAS_LS_KEY = 'gcomp_ideas'
+export const IDEAS_CATEGORIES = [
+  { id: 'names', label: 'Names' },
+  { id: 'words', label: 'Words' },
+  { id: 'phrases', label: 'Phrases' },
+]
+
+export function lsGet(key, fallback) {
+  try { return JSON.parse(localStorage.getItem(key)) ?? fallback } catch { return fallback }
+}
+
+export function lsSet(key, val) {
+  try { localStorage.setItem(key, JSON.stringify(val)) } catch {}
+}
+
+export function stickyTilt(id) {
+  let h = 0
+  for (let i = 0; i < (id || '').length; i++) h = (h * 31 + id.charCodeAt(i)) | 0
+  return ((h % 5) - 2) * 0.8
+}
+
+export function normalizeSticky(sticky, index = 0) {
+  const pinnedStickies = sticky.pinned_stickies ?? sticky.pinned ?? false
+  const pinnedJournal = sticky.pinned_journal ?? false
+  return {
+    size: 'normal',
+    color: 'yellow',
+    fontSize: '0.92em',
+    archived: false,
+    sort_order: index,
+    journal_sort_order: index,
+    ...sticky,
+    pinned_stickies: pinnedStickies,
+    pinned_journal: pinnedJournal,
+    sort_order: Number.isFinite(Number(sticky.sort_order)) ? Number(sticky.sort_order) : index,
+    journal_sort_order: Number.isFinite(Number(sticky.journal_sort_order)) ? Number(sticky.journal_sort_order) : index,
+  }
+}
+
+export function sortStickies(list) {
+  return [...list].sort((a, b) => {
+    const ap = a.pinned_stickies ? 0 : 1
+    const bp = b.pinned_stickies ? 0 : 1
+    if (ap !== bp) return ap - bp
+    const ao = Number.isFinite(Number(a.sort_order)) ? Number(a.sort_order) : 0
+    const bo = Number.isFinite(Number(b.sort_order)) ? Number(b.sort_order) : 0
+    if (ao !== bo) return ao - bo
+    return new Date(b.created || 0) - new Date(a.created || 0)
+  })
+}
+
+export function sortJournalPins(list) {
+  return [...list].sort((a, b) => {
+    const ao = Number.isFinite(Number(a.journal_sort_order)) ? Number(a.journal_sort_order) : 0
+    const bo = Number.isFinite(Number(b.journal_sort_order)) ? Number(b.journal_sort_order) : 0
+    if (ao !== bo) return ao - bo
+    return new Date(b.created || 0) - new Date(a.created || 0)
+  })
+}
+
+export function stickyTitle(text, limit = 50) {
+  return (text || '').trim().slice(0, limit) || '(untitled)'
+}
+
+export function importNoteText(date = new Date()) {
+  const yyyy = date.getFullYear()
+  const mm = String(date.getMonth() + 1).padStart(2, '0')
+  const dd = String(date.getDate()).padStart(2, '0')
+  return `Imported from sticky on ${yyyy}-${mm}-${dd}. Needs review.`
+}
+
+export function scrollAndFlashEntry(id) {
+  const el = document.getElementById(`gcomp-entry-${id}`)
+  if (!el) return
+  el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  const orig = el.style.background
+  el.style.transition = 'background 0.3s'
+  el.style.background = 'rgba(255, 220, 100, 0.4)'
+  window.setTimeout(() => { el.style.background = orig }, 1500)
+}


### PR DESCRIPTION
## What changed
- imports `session_log` records into the dedicated Supabase `session_log` table during JSON import
- includes imported session log rows in the import success summary when there are no conflicts
- lets Dashboard Recent entries fall back to `created_at` when `updated_at`/`updated` are missing
- prevents an empty remote session array from skipping the local/session-log sync path check incorrectly

## Why
Session log data lives outside the normal `CATEGORIES` import path, so full and top-up session imports were not counting or persisting those rows correctly. The Dashboard recent list was also missing entries that only had `created_at`, and the session log loader needed to distinguish `null` from an intentionally empty remote array.

## Impact
The existing `sessions_0_to_24_FULL_import.json` and `sessions_25_26_topup.json` imports should now land cleanly and show the expected added-count behavior, while Dashboard Recent and Session Log loading behave more reliably.

## Validation
- `npm.cmd run build`
- Vite production build completed successfully