### PR TITLE
Session import fix + Notes restructure + Manuscript M2 + Review Queue + PR #13 polish (bug fixes, em-conversion, tab colors, Ideas sub-tab, Items sub-tab, Dashboard search, nav icons)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
-// Guardians of Lajen Compendium — Service Worker v17
-const CACHE_NAME = 'gol-compendium-v17';
+// Guardians of Lajen Compendium — Service Worker v18
+const CACHE_NAME = 'gol-compendium-v18';
 const PRECACHE_URLS = ['/', '/index.html', '/icon-192.png', '/icon-512.png'];
 
 self.addEventListener('install', event => {
@@ -33,3 +33,4 @@ self.addEventListener('fetch', event => {
       }))
   );
 });
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { useDB } from './hooks/useDB'
 import { useAutoBackup } from './hooks/useAutoBackup'
-import { CATS, TAB_RAINBOW, uid } from './constants'
+import { CATS, TAB_ORDER_FOR_COLORS, TAB_RAINBOW, uid } from './constants'
 
 import Dashboard from './tabs/Dashboard'
 import Characters from './tabs/Characters'
@@ -29,12 +29,7 @@ import SessionLog from './tabs/SessionLog'
 import Glossary from './tabs/Glossary'
 import IOBar from './components/common/IOBar'
 
-const TAB_ORDER = [
-  'dashboard','wiki','glossary','characters','familytree','world','locations','map',
-  'manuscript','scenes','timeline','calendar',
-  'inventory','flags','questions','canon','spellings',
-  'notes','tools','sessionlog'
-]
+const TAB_ORDER = TAB_ORDER_FOR_COLORS
 
 const VALID_TABS = new Set(TAB_ORDER)
 
@@ -140,7 +135,7 @@ export default function App() {
     if (entryId) {
       setTimeout(() => {
         window.dispatchEvent(new CustomEvent('gcomp_expand', { detail: { id: entryId } }))
-      }, 150)
+      }, 300)
     }
   }, [goTo])
 
@@ -151,7 +146,7 @@ export default function App() {
 
   const adjFont = useCallback((d) => {
     setFontSize(prev => {
-      const next = Math.max(10, Math.min(20, prev + d))
+      const next = Math.max(11, Math.min(22, prev + d))
       try { localStorage.setItem('gcomp_font_size', String(next)) } catch {}
       return next
     })

--- a/src/components/common/GenericListTab.jsx
+++ b/src/components/common/GenericListTab.jsx
@@ -5,7 +5,7 @@ import AlphabetJumpBar from './AlphabetJumpBar'
 import { SL, highlight } from '../../constants'
 import { scrollAndFlashEntry } from './entryNav'
 
-const SIZE_COLS = { XS: 5, S: 4, M: 3, L: 2, XL: 1 }
+const COLS_MAP = { XS: 5, S: 4, M: 3, L: 2, XL: 1 }
 
 export default function GenericListTab({
   catKey, color, icon, label, fields, db,
@@ -13,11 +13,15 @@ export default function GenericListTab({
   columns, columnRule,
   navSearch,
   getJumpName,
+  entityKey,
+  tabColor,
 }) {
   const entries = db.db[catKey] || []
   const [search, setSearch] = useState('')
-  const [colSize, setColSize] = useState(() => {
-    try { return localStorage.getItem(`colsize_${label}`) || 'M' } catch { return 'M' }
+  const accent = tabColor || color
+  const storageKey = entityKey || catKey
+  const [cols, setCols] = useState(() => {
+    try { return localStorage.getItem(`${storageKey}_cols`) || 'M' } catch { return 'M' }
   })
   const [fS, setFS] = useState('all')
   const [expanded, setExpanded] = useState(null)
@@ -26,7 +30,7 @@ export default function GenericListTab({
   const [confirmId, setConfirmId] = useState(null)
   const [sortMode, setSortMode] = useState('alpha')
   const [autoOnly, setAutoOnly] = useState(false)
-  const cols = SIZE_COLS[colSize] || 3
+  const colCount = COLS_MAP[cols] || 3
   const autoCount = entries.filter(e => e.auto_imported === true).length
 
   useEffect(() => { setSearch(navSearch || '') }, [navSearch])
@@ -46,9 +50,9 @@ export default function GenericListTab({
     return () => window.removeEventListener('gcomp_expand', onExpand)
   }, [entries])
 
-  function changeColSize(sz) {
-    setColSize(sz)
-    try { localStorage.setItem(`colsize_${label}`, sz) } catch {}
+  function setColsPersist(v) {
+    setCols(v)
+    try { localStorage.setItem(`${storageKey}_cols`, v) } catch {}
   }
 
   const filtered = entries
@@ -105,12 +109,12 @@ export default function GenericListTab({
       <div className="tbar">
         <div style={{ display: 'flex', gap: 3 }}>
           {['XS', 'S', 'M', 'L', 'XL'].map(sz => (
-            <button key={sz} onClick={() => changeColSize(sz)} style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, cursor: 'pointer', background: colSize === sz ? color : 'none', color: colSize === sz ? '#000' : 'var(--dim)', border: `1px solid ${colSize === sz ? color : 'var(--brd)'}` }}>{sz}</button>
+            <button key={sz} onClick={() => setColsPersist(sz)} style={{ fontSize: '0.77em', padding: '2px 7px', borderRadius: 4, cursor: 'pointer', background: cols === sz ? `${accent}22` : 'transparent', color: cols === sz ? accent : 'var(--dim)', border: `1px solid ${cols === sz ? accent : 'var(--brd)'}` }}>{sz}</button>
           ))}
         </div>
         <input className="sx" placeholder="Search..." value={search} onChange={e => setSearch(e.target.value)} />
         {autoCount > 0 && (
-          <button onClick={() => setAutoOnly(v => !v)} style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: `1px solid ${autoOnly ? '#ffcc00' : 'var(--brd)'}`, background: autoOnly ? '#ffcc0022' : 'none', color: autoOnly ? '#ffcc00' : 'var(--dim)', cursor: 'pointer' }}>
+          <button onClick={() => setAutoOnly(v => !v)} style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: `1px solid ${autoOnly ? accent : 'var(--brd)'}`, background: autoOnly ? `${accent}22` : 'none', color: autoOnly ? accent : 'var(--dim)', cursor: 'pointer' }}>
             📥 Auto-imported ({autoCount})
           </button>
         )}
@@ -119,7 +123,7 @@ export default function GenericListTab({
           <option value="newest">Newest first</option>
           <option value="oldest">Oldest first</option>
         </select>
-        <button className="btn btn-primary btn-sm" style={{ background: color }} onClick={openAdd}>+ Add</button>
+        <button className="btn btn-primary btn-sm" style={{ background: accent }} onClick={openAdd}>+ Add</button>
       </div>
 
       <div className="tbar" style={{ paddingTop: 0 }}>
@@ -133,22 +137,22 @@ export default function GenericListTab({
       </div>
 
       {getJumpName && filtered.length > 0 && (
-        <AlphabetJumpBar entries={filtered} getName={getJumpName} onJump={target => scrollAndFlashEntry(target.id)} color={color} />
+        <AlphabetJumpBar entries={filtered} getName={getJumpName} onJump={target => scrollAndFlashEntry(target.id)} color={accent} />
       )}
 
-      <div className="cg" style={listStyle}>
+      <div className="cg" style={{ ...listStyle, display: columns && columns > 1 ? undefined : 'grid', gridTemplateColumns: columns && columns > 1 ? undefined : `repeat(${colCount}, 1fr)`, gap: columns && columns > 1 ? undefined : 8 }}>
         {!filtered.length && (
           <div className="empty">
             <div className="empty-icon">{icon}</div>
             <p>No {label.toLowerCase()} yet.</p>
-            <button className="btn btn-primary" style={{ background: color }} onClick={openAdd}>+ Add {label.slice(0, -1)}</button>
+            <button className="btn btn-primary" style={{ background: accent }} onClick={openAdd}>+ Add {label.slice(0, -1)}</button>
           </div>
         )}
         {filtered.map((e, i) => {
           const isOpen = expanded === e.id
           const ts = e.updated_at || e.updated || e.created
           return (
-            <div key={e.id} id={`gcomp-entry-${e.id}`} className="entry-card" style={{ '--card-color': color, background: i % 2 === 1 ? 'rgba(255,255,255,.01)' : undefined, breakInside: 'avoid', marginBottom: 6 }} onClick={() => setExpanded(isOpen ? null : e.id)}>
+            <div key={e.id} id={`gcomp-entry-${e.id}`} className="entry-card" style={{ '--card-color': accent, background: i % 2 === 1 ? 'rgba(255,255,255,.01)' : undefined, breakInside: 'avoid', marginBottom: 6 }} onClick={() => setExpanded(isOpen ? null : e.id)}>
               <div className="entry-title" dangerouslySetInnerHTML={{ __html: highlight(e.display_name || e.name || e.word || '', search) }} />
               <div className="entry-meta">{badges(e)}</div>
 
@@ -157,7 +161,7 @@ export default function GenericListTab({
                   <div className="entry-detail">
                     {renderDetail ? renderDetail(e) : fields.filter(f => f.k !== 'name' && e[f.k]).map(f => (
                       <div key={f.k} style={{ marginBottom: 3 }}>
-                        <strong style={{ color, fontSize: 'var(--fs-xs)', textTransform: 'uppercase' }}>{f.l}: </strong>
+                        <strong style={{ color: accent, fontSize: 'var(--fs-xs)', textTransform: 'uppercase' }}>{f.l}: </strong>
                         {String(e[f.k])}
                       </div>
                     ))}
@@ -165,7 +169,7 @@ export default function GenericListTab({
                   {e.notes && <div className="entry-notes">{e.notes}</div>}
                   {ts && <div className="entry-timestamp">{e.updated_at && e.updated_at !== e.created ? `Edited ${fmtDate(e.updated_at)}` : e.created ? `Added ${fmtDate(e.created)}` : ''}</div>}
                   <div className="entry-actions">
-                    <button className="btn btn-sm btn-outline" style={{ color, borderColor: color }} onClick={ev => { ev.stopPropagation(); openEdit(e) }}>✎ Edit</button>
+                    <button className="btn btn-sm btn-outline" style={{ color: accent, borderColor: accent }} onClick={ev => { ev.stopPropagation(); openEdit(e) }}>✎ Edit</button>
                     {extraActions && extraActions(e)}
                     <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544' }} onClick={ev => { ev.stopPropagation(); setConfirmId(e.id) }}>✕</button>
                   </div>
@@ -176,8 +180,8 @@ export default function GenericListTab({
         })}
       </div>
 
-      <Modal open={modalOpen} onClose={closeModal} title={`${editing?.id ? 'Edit' : 'Add'} ${label.slice(0, -1)}`} color={color}>
-        <EntryForm fields={fields} entry={editing || {}} onSave={handleSave} onCancel={closeModal} color={color} label={label} db={db} />
+      <Modal open={modalOpen} onClose={closeModal} title={`${editing?.id ? 'Edit' : 'Add'} ${label.slice(0, -1)}`} color={accent}>
+        <EntryForm fields={fields} entry={editing || {}} onSave={handleSave} onCancel={closeModal} color={accent} label={label} db={db} />
       </Modal>
 
       {confirmId && (

--- a/src/constants.js
+++ b/src/constants.js
@@ -103,32 +103,27 @@ export const CATS = {
 
 export const RAINBOW = ['#ff69b4','#ff6b6b','#ff4433','#ff5533','#ff7040','#ffaa33','#ffcc00','#aacc44','#44bb44','#00ccaa','#00ddff','#44aaff','#3388ff','#6655ff','#8844ff','#aa44ff','#cc44ff','#ff44cc']
 
-export const TAB_RAINBOW = {
-  dashboard:     '#ffffff',  // white — neutral
-  wiki:          '#ff69b4',  // RAINBOW[0] Pink
-  glossary:      '#ff6b6b',  // RAINBOW[1] Coral
-  characters:    '#ff4433',  // RAINBOW[2] Red
-  familytree:    '#ff5533',  // RAINBOW[3] Red-Orange
-  world:         '#ff7040',  // RAINBOW[4] Orange
-  locations:     '#ffaa33',  // RAINBOW[5] Amber
-  map:           '#ffcc00',  // RAINBOW[6] Yellow
-  manuscript:    '#aacc44',  // RAINBOW[7] Yellow-Green
-  scenes:        '#44bb44',  // RAINBOW[8] Green
-  timeline:      '#00ccaa',  // RAINBOW[9] Teal
-  eras:          '#00ddff',  // RAINBOW[10] Cyan
-  calendar:      '#44aaff',  // RAINBOW[11] Sky Blue
-  inventory:     '#3388ff',  // RAINBOW[12] Blue
-  wardrobe:      '#6655ff',  // RAINBOW[13] Indigo
-  items:         '#8844ff',  // RAINBOW[14] Violet
-  flags:         '#aa44ff',  // RAINBOW[15] Purple
-  questions:     '#cc44ff',  // RAINBOW[16] Magenta
-  canon:         '#ff44cc',  // RAINBOW[17] Hot Pink
-  spellings:     '#ff69b4',  // RAINBOW[0] cycles back to Pink
-  notes:         '#ff6b6b',  // RAINBOW[1] Coral
-  journal:       '#ff4433',  // RAINBOW[2] Red
-  tools:         '#ff5533',  // RAINBOW[3] Red-Orange
-  sessionlog:    '#ff7040',  // RAINBOW[4] Orange
+export const RAINBOW_HEX = [
+  '#ff69b4', '#ff6b6b', '#ff4433', '#ff5533', '#ff7040', '#ffaa33',
+  '#ffcc00', '#aacc44', '#44bb44', '#00ccaa', '#00ddff', '#44aaff',
+  '#3388ff', '#6655ff', '#8844ff', '#aa44ff', '#cc44ff', '#ff44cc',
+]
+
+export function buildTabRainbow(tabOrder) {
+  const map = { dashboard: '#ffffff' }
+  const cyclable = tabOrder.filter(t => t !== 'dashboard')
+  cyclable.forEach((k, i) => { map[k] = RAINBOW_HEX[i % RAINBOW_HEX.length] })
+  return map
 }
+
+export const TAB_ORDER_FOR_COLORS = [
+  'dashboard', 'wiki', 'glossary', 'characters', 'familytree', 'world', 'locations', 'map',
+  'manuscript', 'scenes', 'timeline', 'calendar',
+  'inventory', 'flags', 'questions', 'canon', 'spellings',
+  'notes', 'tools', 'sessionlog',
+]
+
+export const TAB_RAINBOW = buildTabRainbow(TAB_ORDER_FOR_COLORS)
 
 // ── CSS variable map — kept for backward compatibility ─────────
 // Some older tab files reference these; they still work via globals.css

--- a/src/tabs/CalendarTab.jsx
+++ b/src/tabs/CalendarTab.jsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react'
 import Modal from '../components/common/Modal'
-import { MONTHS, WEEKDAYS, SEASON_TAG_COLORS, ERA_TIMELINE, ERA_SPANS, uid } from '../constants'
+import { MONTHS, WEEKDAYS, SEASON_TAG_COLORS, TAB_RAINBOW, ERA_TIMELINE, ERA_SPANS, uid } from '../constants'
 
 const MC = ['#00ffcc','#66cc99','#ff3366','#f4c430','#cc6622','#990000','#4477cc','#7799cc','#a9c0d3','#7fff00','#bb77cc','#9400d3']
-const CAL_COLOR = '#4cc9f0'
+const CAL_COLOR = TAB_RAINBOW['calendar'] || '#aaaaaa'
 const ERA_TABLE = [
   { cat: 'EARLY HUMANITY', rows: [
     { mn:'~300,000 BC', ev:'First Homo sapiens (Africa)',          my:301554, hc:-2568920, lc:2569240, mc:35394 },
@@ -73,7 +73,7 @@ function EraEditModal({ item, type, onSave, onClose }) {
   return (
     <div style={{ position: 'fixed', inset: 0, zIndex: 400, background: 'rgba(0,0,0,.8)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20 }}>
       <div style={{ background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 12, padding: 20, width: '100%', maxWidth: 420, maxHeight: '90vh', overflowY: 'auto' }}>
-        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1em', color: 'var(--cca)', marginBottom: 14 }}>
+        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1em', color: CAL_COLOR, marginBottom: 14 }}>
           ✎ Edit {type === 'timeline' ? 'Timeline Entry' : 'Era Span'}
         </div>
         {type === 'timeline' ? (
@@ -83,7 +83,7 @@ function EraEditModal({ item, type, onSave, onClose }) {
         )}
         <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 6 }}>
           <button className="btn btn-outline btn-sm" onClick={onClose}>Cancel</button>
-          <button className="btn btn-primary btn-sm" style={{ background: 'var(--cca)', color: '#000' }}
+          <button className="btn btn-primary btn-sm" style={{ background: CAL_COLOR, color: '#000' }}
             onClick={() => { onSave(form); onClose() }}>Save</button>
         </div>
       </div>
@@ -141,7 +141,7 @@ function ErasView({ db }) {
 
       {/* Visual timeline */}
       <div style={{ background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 'var(--rl)', padding: 16, marginBottom: 16 }}>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1em', color: 'var(--cca)', marginBottom: 12 }}>Timeline</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1em', color: CAL_COLOR, marginBottom: 12 }}>Timeline</div>
         <div style={{ position: 'relative', paddingLeft: 90 }}>
           {timeline.map((e, i) => {
             const isLast = i === timeline.length - 1
@@ -171,12 +171,12 @@ function ErasView({ db }) {
 
       {/* Conversion table */}
       <div style={{ background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 'var(--rl)', padding: 16, marginBottom: 16 }}>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1em', color: 'var(--cca)', marginBottom: 4 }}>Conversion Table</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1em', color: CAL_COLOR, marginBottom: 4 }}>Conversion Table</div>
         <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginBottom: 8 }}>Anchor: HC 320 = 1554 AD. Earth-history sections collapsed by default.</div>
         <div style={{ overflowX: 'auto' }}>
           {ERA_TABLE.map(cat => (
             <details key={cat.cat} open={lajenCore.has(cat.cat)} style={{ marginBottom: 4 }}>
-              <summary style={{ fontSize: '0.77em', fontWeight: 700, color: 'var(--cca)', padding: '6px 4px', cursor: 'pointer', userSelect: 'none', textTransform: 'uppercase', letterSpacing: '.06em', listStyle: 'none', display: 'flex', alignItems: 'center', gap: 6 }}>
+              <summary style={{ fontSize: '0.77em', fontWeight: 700, color: CAL_COLOR, padding: '6px 4px', cursor: 'pointer', userSelect: 'none', textTransform: 'uppercase', letterSpacing: '.06em', listStyle: 'none', display: 'flex', alignItems: 'center', gap: 6 }}>
                 {cat.cat} <span style={{ fontSize: '0.69em', color: 'var(--mut)', fontWeight: 400, textTransform: 'none' }}>({cat.rows.length} entries)</span>
               </summary>
               <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.77em', marginBottom: 4 }}>
@@ -195,7 +195,7 @@ function ErasView({ db }) {
                       <td style={{ padding: '5px 6px', textAlign: 'right', color: 'var(--dim)' }}>{fmt(r.my)}</td>
                       <td style={{ padding: '5px 6px', textAlign: 'right', color: 'var(--cc)', whiteSpace: 'nowrap' }}>{typeof r.hc==='number'&&r.hc<0?`HC ${fmt(r.hc)}`:`HC ${r.hc}`}</td>
                       <td style={{ padding: '5px 6px', textAlign: 'right', color: 'var(--cl)', whiteSpace: 'nowrap' }}>{fmt(r.lc)} LY</td>
-                      <td style={{ padding: '5px 6px', textAlign: 'right', color: 'var(--cca)', whiteSpace: 'nowrap' }}>{fmt(r.mc)} MY</td>
+                      <td style={{ padding: '5px 6px', textAlign: 'right', color: CAL_COLOR, whiteSpace: 'nowrap' }}>{fmt(r.mc)} MY</td>
                     </tr>
                   ))}
                 </tbody>
@@ -299,7 +299,7 @@ export default function CalendarTab({ db }) {
       {activeTab === 'calendar' && (
         <div>
           <div style={{ textAlign: 'center', padding: '8px 0 6px' }}>
-            <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.08em', color: 'var(--cca)' }}>🌙 The Lajen Calendar</div>
+            <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.08em', color: CAL_COLOR }}>🌙 The Lajen Calendar</div>
             <div style={{ fontSize: '0.69em', color: 'var(--mut)' }}>12 months × 30 days · 5-day week · 4 seasons × 90 days</div>
           </div>
 
@@ -309,16 +309,16 @@ export default function CalendarTab({ db }) {
               {['XS','S','M','L','XL'].map(s => (
                 <button key={s} onClick={() => { setGridSize(s); try { localStorage.setItem('colsize_calendar', s) } catch {} }}
                   style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, cursor: 'pointer',
-                    background: gridSize === s ? 'var(--cca)' : 'none',
+                    background: gridSize === s ? CAL_COLOR : 'none',
                     color: gridSize === s ? '#000' : 'var(--dim)',
-                    border: `1px solid ${gridSize === s ? 'var(--cca)' : 'var(--brd)'}` }}>{s}</button>
+                    border: `1px solid ${gridSize === s ? CAL_COLOR : 'var(--brd)'}` }}>{s}</button>
               ))}
             </div>
             <button onClick={toggleExpandAll}
               style={{ fontSize: '0.85em', padding: '4px 14px', borderRadius: 8, cursor: 'pointer',
-                background: expandAll ? 'var(--cca)' : 'var(--card)',
+                background: expandAll ? CAL_COLOR : 'var(--card)',
                 color: expandAll ? '#000' : 'var(--dim)',
-                border: `1px solid ${expandAll ? 'var(--cca)' : 'var(--brd)'}` }}>
+                border: `1px solid ${expandAll ? CAL_COLOR : 'var(--brd)'}` }}>
               {expandAll ? '⊟ Collapse All' : '⊞ Expand All'}
             </button>
             {openMonths.size > 0 && !expandAll && (
@@ -399,7 +399,7 @@ export default function CalendarTab({ db }) {
           <Modal open={!!dayModal}
             onClose={() => { setDayModal(null); setDayText(''); setEditingEntry(null) }}
             title={dayModal ? `${MONTHS[dayModal.mi]?.n}, Day ${dayModal.day}` : ''}
-            color="var(--cca)">
+            color={CAL_COLOR}>
             {dayModal && (
               <>
                 {getEntriesForDay(dayModal.mi, dayModal.day).map(e => (
@@ -420,7 +420,7 @@ export default function CalendarTab({ db }) {
                 </div>
                 <div className="modal-actions">
                   <button className="btn btn-outline" onClick={() => { setDayModal(null); setDayText(''); setEditingEntry(null) }}>Cancel</button>
-                  <button className="btn btn-primary" style={{ background: 'var(--cca)' }} onClick={saveEntry}>
+                  <button className="btn btn-primary" style={{ background: CAL_COLOR }} onClick={saveEntry}>
                     {editingEntry ? 'Update' : 'Save'}
                   </button>
                 </div>

--- a/src/tabs/Canon.jsx
+++ b/src/tabs/Canon.jsx
@@ -1,4 +1,5 @@
 import GenericListTab from '../components/common/GenericListTab'
+import { TAB_RAINBOW } from '../constants'
 
 const CANON_FIELDS = [
   { k: 'name', l: 'Decision', t: 'text', r: true },
@@ -10,12 +11,14 @@ export default function Canon({ db, navSearch }) {
   return (
     <GenericListTab
       catKey="canon"
-      color="#ff48c4"
+      color={TAB_RAINBOW.canon}
       icon="✦"
       label="Canon Decisions"
       fields={CANON_FIELDS}
       db={db}
       navSearch={navSearch}
+      entityKey="canon"
+      tabColor={TAB_RAINBOW.canon}
     />
   )
 }

--- a/src/tabs/Characters.jsx
+++ b/src/tabs/Characters.jsx
@@ -5,8 +5,10 @@ import Modal from '../components/common/Modal'
 import EntryForm from '../components/common/EntryForm'
 import AlphabetJumpBar from '../components/common/AlphabetJumpBar'
 import { scrollAndFlashEntry } from '../components/common/entryNav'
-import { CHAR_FIELDS, highlight, SL, uid, hexToRgba, lerpColor } from '../constants'
+import { CHAR_FIELDS, TAB_RAINBOW, highlight, SL, uid, hexToRgba, lerpColor } from '../constants'
 import FilterPopup from '../components/common/FilterPopup'
+
+const tabColor = TAB_RAINBOW.characters
 
 const PRESET_LABELS = [
   { key: 'generic_male_no_wings',    label: 'Generic Male — No Wings' },
@@ -110,6 +112,10 @@ export default function Characters({ db, goTo, tab, navSearch }) {
     }
     if (autoOnly && e.auto_imported !== true) return false
     return true
+  }).sort((a, b) => {
+    const an = (a.display_name || a.name || '').toLowerCase()
+    const bn = (b.display_name || b.name || '').toLowerCase()
+    return an.localeCompare(bn)
   })
 
   function handleSave(entry) {
@@ -193,9 +199,9 @@ export default function Characters({ db, goTo, tab, navSearch }) {
           {['XS','S','M','L','XL'].map(sz => (
             <button key={sz} onClick={() => changeColSize(sz)}
               style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, cursor: 'pointer',
-                background: colSize === sz ? '#e63946' : 'none',
+                background: colSize === sz ? tabColor : 'none',
                 color: colSize === sz ? '#fff' : 'var(--dim)',
-                border: `1px solid ${colSize === sz ? '#e63946' : 'var(--brd)'}` }}>{sz}</button>
+                border: `1px solid ${colSize === sz ? tabColor : 'var(--brd)'}` }}>{sz}</button>
           ))}
         </div>
         <input className="sx" placeholder="Search characters…" value={search} onChange={e => setSearch(e.target.value)} />
@@ -213,7 +219,7 @@ export default function Characters({ db, goTo, tab, navSearch }) {
           ))}
         </div>
         <FilterPopup
-          color="#e63946"
+          color={tabColor}
           filters={[
             { key: 'element', label: 'Element', options: [
               { value: 'Water', label: '💧 Water' },
@@ -234,19 +240,19 @@ export default function Characters({ db, goTo, tab, navSearch }) {
           onChange={(key, vals) => setFilterValues(prev => ({ ...prev, [key]: vals }))}
         />
         {autoCount > 0 && (
-          <button onClick={() => setAutoOnly(v => !v)} style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: `1px solid ${autoOnly ? '#ffcc00' : 'var(--brd)'}`, background: autoOnly ? '#ffcc0022' : 'none', color: autoOnly ? '#ffcc00' : 'var(--dim)', cursor: 'pointer' }}>
+          <button onClick={() => setAutoOnly(v => !v)} style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: `1px solid ${autoOnly ? tabColor : 'var(--brd)'}`, background: autoOnly ? `${tabColor}22` : 'none', color: autoOnly ? tabColor : 'var(--dim)', cursor: 'pointer' }}>
             📥 Auto-imported ({autoCount})
           </button>
         )}
-        <button className="btn btn-primary btn-sm" style={{ background: '#e63946' }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add</button>
+        <button className="btn btn-primary btn-sm" style={{ background: tabColor }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add</button>
       </div>
 
-      <AlphabetJumpBar entries={filtered} getName={c => c.display_name || c.name} onJump={target => scrollAndFlashEntry(target.id)} color="#e63946" />
+      <AlphabetJumpBar entries={filtered} getName={c => c.display_name || c.name} onJump={target => scrollAndFlashEntry(target.id)} color={tabColor} />
 
       <div className="cg">
         {!filtered.length && (
           <div className="empty"><div className="empty-icon">👤</div><p>No characters yet.</p>
-            <button className="btn btn-primary" style={{ background: '#e63946' }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add Character</button>
+            <button className="btn btn-primary" style={{ background: tabColor }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add Character</button>
           </div>
         )}
         {filtered.map((e, i) => {
@@ -288,7 +294,7 @@ export default function Characters({ db, goTo, tab, navSearch }) {
                               style={{ width: 100, height: 'auto', borderRadius: 'var(--r)', border: '1px solid var(--cc)', cursor: 'zoom-in' }}
                               onClick={ev => { ev.stopPropagation(); setLightboxSrc(e.portrait_canvas) }}
                             />
-                            <div style={{ fontSize: 8, color: '#e63946', marginTop: 2, cursor: 'pointer' }} onClick={ev => { ev.stopPropagation(); setPortraitCharId(e.id) }}>🎨 Edit</div>
+                            <div style={{ fontSize: '0.62em', color: '#e63946', marginTop: 2, cursor: 'pointer' }} onClick={ev => { ev.stopPropagation(); setPortraitCharId(e.id) }}>🎨 Edit</div>
                           </div>
                         ) : (
                           <div style={{ width: 80, height: 80, border: '1px dashed var(--brd)', borderRadius: 'var(--r)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', color: 'var(--mut)', fontSize: '0.69em', cursor: 'pointer', gap: 2 }}
@@ -303,10 +309,10 @@ export default function Characters({ db, goTo, tab, navSearch }) {
                               onClick={ev => { ev.stopPropagation(); setLightboxSrc(e.reference_image) }}
                             />
                             <div style={{ display: 'flex', gap: 4, marginTop: 2, justifyContent: 'center' }}>
-                              <label style={{ fontSize: 8, color: 'var(--dim)', cursor: 'pointer' }}>📎
+                              <label style={{ fontSize: '0.62em', color: 'var(--dim)', cursor: 'pointer' }}>📎
                                 <input type="file" accept="image/*" style={{ display: 'none' }} onChange={ev => { const f=ev.target.files[0];if(!f)return;const r=new FileReader();r.onload=e2=>{db.upsertEntry('characters',{...e,reference_image:e2.target.result})};r.readAsDataURL(f) }} />
                               </label>
-                              <span style={{ fontSize: 8, color: '#ff3355', cursor: 'pointer' }} onClick={ev => { ev.stopPropagation(); db.upsertEntry('characters',{...e,reference_image:null}) }}>✕</span>
+                              <span style={{ fontSize: '0.62em', color: '#ff3355', cursor: 'pointer' }} onClick={ev => { ev.stopPropagation(); db.upsertEntry('characters',{...e,reference_image:null}) }}>✕</span>
                             </div>
                           </div>
                         ) : (
@@ -609,18 +615,18 @@ function PortraitTool({ charId, db, onClose, palette, presetLabels }) {
                     onClick={() => { if (src) { db.upsertEntry('characters',{...ch,portrait_base:key,portrait_custom:null,portrait_canvas:null}); loadBase(src) } }}>
                     {src
                       ? <img src={src} style={{ width:'100%', height:60, objectFit:'contain', filter:'invert(1) brightness(.7)' }} alt={label} />
-                      : <div style={{ height:60, display:'flex', alignItems:'center', justifyContent:'center', fontSize:9, color:'var(--mut)', flexDirection:'column', gap:2 }}>
+                      : <div style={{ height:60, display:'flex', alignItems:'center', justifyContent:'center', fontSize: '0.69em', color:'var(--mut)', flexDirection:'column', gap:2 }}>
                           <span>No image</span>
-                          <label style={{ fontSize:8, color:'var(--cc)', cursor:'pointer' }}>Upload<input type="file" accept="image/*" style={{display:'none'}} onChange={e => uploadPreset(key, e)} /></label>
+                          <label style={{ fontSize: '0.62em', color:'var(--cc)', cursor:'pointer' }}>Upload<input type="file" accept="image/*" style={{display:'none'}} onChange={e => uploadPreset(key, e)} /></label>
                         </div>
                     }
-                    <div style={{ fontSize: 8, color: sel?'var(--cc)':'var(--dim)', marginTop: 2 }}>{label}</div>
+                    <div style={{ fontSize: '0.62em', color: sel?'var(--cc)':'var(--dim)', marginTop: 2 }}>{label}</div>
                   </div>
                 )
               })}
             </div>
             <div className="field"><label>Upload Custom Image</label>
-              <label style={{ display:'inline-block', padding:'6px 12px', background:'var(--card)', border:'1px solid var(--brd)', borderRadius:'var(--r)', cursor:'pointer', fontSize:11 }}>
+              <label style={{ display:'inline-block', padding:'6px 12px', background:'var(--card)', border:'1px solid var(--brd)', borderRadius:'var(--r)', cursor:'pointer', fontSize: '0.85em' }}>
                 📎 Choose Image
                 <input type="file" accept="image/*" style={{ display:'none' }} onChange={e => {
                   const f=e.target.files[0]; if(!f) return
@@ -637,14 +643,14 @@ function PortraitTool({ charId, db, onClose, palette, presetLabels }) {
               <button className="btn btn-sm btn-outline" onClick={undo}>↩ Undo</button>
               <button className="btn btn-sm btn-outline" onClick={reset}>↺ Reset</button>
               <div style={{ display:'flex', alignItems:'center', gap:4 }}>
-                <span style={{ fontSize:10, color:'var(--dim)' }}>Tol:</span>
+                <span style={{ fontSize: '0.77em', color:'var(--dim)' }}>Tol:</span>
                 <input type="range" min={4} max={80} value={tolerance} style={{ width:70 }} onChange={e => setTolerance(parseInt(e.target.value))} />
-                <span style={{ fontSize:10, color:'var(--cca)' }}>{tolerance}</span>
+                <span style={{ fontSize: '0.77em', color:'var(--cca)' }}>{tolerance}</span>
               </div>
               <div style={{ display:'flex', alignItems:'center', gap:4 }}>
-                <span style={{ fontSize:10, color:'var(--dim)' }}>Zoom:</span>
+                <span style={{ fontSize: '0.77em', color:'var(--dim)' }}>Zoom:</span>
                 <input type="range" min={1} max={4} step={0.25} value={zoom} style={{ width:60 }} onChange={e => setZoom(parseFloat(e.target.value))} />
-                <span style={{ fontSize:10, color:'var(--cca)' }}>{zoom}×</span>
+                <span style={{ fontSize: '0.77em', color:'var(--cca)' }}>{zoom}×</span>
               </div>
               <div style={{ display:'flex', gap:4 }}>
                 <button className={`fp ${fillMode==='flat'?'active':''}`} style={{ color:'var(--cc)' }} onClick={() => setFillMode('flat')}>Flat</button>
@@ -653,12 +659,12 @@ function PortraitTool({ charId, db, onClose, palette, presetLabels }) {
             </div>
             <div style={{ display:'flex', gap:8, alignItems:'center', marginBottom:8 }}>
               <input type="color" value={flatColor} onChange={e => setFlatColor(e.target.value)} style={{ width:36, height:30, padding:0, border:'1px solid var(--brd)', borderRadius:4, cursor:'pointer' }} />
-              <span style={{ fontSize:11, color:'var(--dim)' }}>Current color</span>
+              <span style={{ fontSize: '0.85em', color:'var(--dim)' }}>Current color</span>
               <div style={{ width:20, height:20, borderRadius:'50%', background:flatColor, border:'2px solid rgba(255,255,255,.2)' }} />
             </div>
             {recentColors.length > 0 && (
               <div style={{ marginBottom:8 }}>
-                <div style={{ fontSize:9, color:'var(--dim)', marginBottom:4, textTransform:'uppercase', letterSpacing:'.03em' }}>Recent</div>
+                <div style={{ fontSize: '0.69em', color:'var(--dim)', marginBottom:4, textTransform:'uppercase', letterSpacing:'.03em' }}>Recent</div>
                 <div style={{ display:'flex', flexWrap:'wrap', gap:3 }}>
                   {recentColors.map((c,i) => (
                     <div key={i} style={{ width:18, height:18, borderRadius:3, background:c, border:`2px solid ${c===flatColor?'white':'rgba(255,255,255,.15)'}`, cursor:'pointer' }} onClick={() => setFlatColor(c)} title={c} />
@@ -667,7 +673,7 @@ function PortraitTool({ charId, db, onClose, palette, presetLabels }) {
               </div>
             )}
             <div style={{ marginBottom:8 }}>
-              <div style={{ fontSize:9, color:'var(--dim)', marginBottom:4, textTransform:'uppercase', letterSpacing:'.03em' }}>Palette</div>
+              <div style={{ fontSize: '0.69em', color:'var(--dim)', marginBottom:4, textTransform:'uppercase', letterSpacing:'.03em' }}>Palette</div>
               <div style={{ display:'grid', gridTemplateColumns:'repeat(10,1fr)', gap:2 }}>
                 {PALETTE.map((c,i) => (
                   <div key={i} style={{ width:'100%', paddingBottom:'100%', position:'relative', cursor:'pointer' }} onClick={() => setFlatColor(c)}>
@@ -684,35 +690,35 @@ function PortraitTool({ charId, db, onClose, palette, presetLabels }) {
 
         {tab === 'gradient' && (
           <div>
-            <div style={{ fontSize:10, color:'var(--dim)', marginBottom:8 }}>Set up gradient, then switch to Color Tool and click a region.</div>
+            <div style={{ fontSize: '0.77em', color:'var(--dim)', marginBottom:8 }}>Set up gradient, then switch to Color Tool and click a region.</div>
             <GradientBar stops={gradStops} setStops={setGradStops} selectedStop={selectedStop} setSelectedStop={setSelectedStop} />
             <div style={{ display:'flex', gap:8, flexWrap:'wrap', alignItems:'center', marginTop:8 }}>
               <div style={{ display:'flex', alignItems:'center', gap:4 }}>
-                <span style={{ fontSize:10, color:'var(--dim)' }}>Stop color:</span>
+                <span style={{ fontSize: '0.77em', color:'var(--dim)' }}>Stop color:</span>
                 <input type="color" value={gradStops[selectedStop]?.color||'#c966ff'} onChange={e => setGradStops(prev => prev.map((s,i) => i===selectedStop?{...s,color:e.target.value}:s))} style={{ width:32, height:24, padding:0, border:'1px solid var(--brd)', borderRadius:4, cursor:'pointer' }} />
               </div>
               <div style={{ display:'flex', alignItems:'center', gap:4 }}>
-                <span style={{ fontSize:10, color:'var(--dim)' }}>Angle:</span>
+                <span style={{ fontSize: '0.77em', color:'var(--dim)' }}>Angle:</span>
                 <input type="number" value={gradAngle} min={0} max={360} style={{ width:50 }} onChange={e => setGradAngle(parseInt(e.target.value)||0)} />°
               </div>
-              <select style={{ padding:'3px 5px', borderRadius:4, border:'1px solid var(--brd)', background:'var(--card)', color:'var(--tx)', fontSize:10 }} value={gradType} onChange={e => setGradType(e.target.value)}>
+              <select style={{ padding:'3px 5px', borderRadius:4, border:'1px solid var(--brd)', background:'var(--card)', color:'var(--tx)', fontSize: '0.77em' }} value={gradType} onChange={e => setGradType(e.target.value)}>
                 <option value="linear">Linear</option>
                 <option value="radial">Radial</option>
               </select>
             </div>
             <div style={{ marginTop:12 }}>
               <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center', marginBottom:6 }}>
-                <div style={{ fontSize:9, color:'var(--dim)', textTransform:'uppercase', letterSpacing:'.03em' }}>Saved Gradients</div>
+                <div style={{ fontSize: '0.69em', color:'var(--dim)', textTransform:'uppercase', letterSpacing:'.03em' }}>Saved Gradients</div>
                 <button className="btn btn-sm btn-outline" style={{ color:'var(--cca)', borderColor:'var(--cca)' }} onClick={saveGradient}>💾 Save Current</button>
               </div>
-              {!savedGrads.length && <div style={{ fontSize:10, color:'var(--mut)' }}>No saved gradients yet.</div>}
+              {!savedGrads.length && <div style={{ fontSize: '0.77em', color:'var(--mut)' }}>No saved gradients yet.</div>}
               {savedGrads.map((g,i) => {
                 const preview = `linear-gradient(90deg, ${[...g.stops].sort((a,b)=>a.pos-b.pos).map(s=>`${s.color} ${s.pos*100}%`).join(', ')})`
                 return (
                   <div key={i} style={{ display:'flex', alignItems:'center', gap:8, marginBottom:4 }}>
                     <div style={{ flex:1, height:20, borderRadius:4, background:preview, border:'1px solid var(--brd)', cursor:'pointer' }} onClick={() => { setGradStops(g.stops); setGradAngle(g.angle); setGradType(g.type) }} />
-                    <span style={{ fontSize:10, color:'var(--dim)', minWidth:60 }}>{g.name}</span>
-                    <button style={{ background:'none', border:'none', color:'#ff3355', cursor:'pointer', fontSize:11 }} onClick={() => { const u=savedGrads.filter((_,idx)=>idx!==i); setSavedGrads(u); localStorage.setItem('gcomp_gradients',JSON.stringify(u)) }}>✕</button>
+                    <span style={{ fontSize: '0.77em', color:'var(--dim)', minWidth:60 }}>{g.name}</span>
+                    <button style={{ background:'none', border:'none', color:'#ff3355', cursor:'pointer', fontSize: '0.85em' }} onClick={() => { const u=savedGrads.filter((_,idx)=>idx!==i); setSavedGrads(u); localStorage.setItem('gcomp_gradients',JSON.stringify(u)) }}>✕</button>
                   </div>
                 )
               })}
@@ -779,7 +785,7 @@ function GradientBar({ stops, setStops, selectedStop, setSelectedStop }) {
   }
   return (
     <div>
-      <div style={{ fontSize:9, color:'var(--dim)', marginBottom:4 }}>Click bar to add stop · Drag to move · Right-click to remove</div>
+      <div style={{ fontSize: '0.69em', color:'var(--dim)', marginBottom:4 }}>Click bar to add stop · Drag to move · Right-click to remove</div>
       <canvas ref={canvasRef} width={300} height={28} style={{ width:'100%', maxWidth:300, borderRadius:4, cursor:'crosshair', display:'block', border:'1px solid var(--brd)' }}
         onMouseDown={onMouseDown} onMouseMove={onMouseMove} onMouseUp={onMouseUp} onContextMenu={onContextMenu} />
     </div>

--- a/src/tabs/Dashboard.jsx
+++ b/src/tabs/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { CATS, TAB_RAINBOW } from '../constants'
 
 const TAB_LIST = [
@@ -8,21 +8,41 @@ const TAB_LIST = [
   'notes', 'tools', 'sessionlog',
 ]
 
-const RAINBOW = [
-  '#ff69b4', '#ff6b6b', '#e63946', '#f4442e', '#ff8c00', '#ffb700', '#ffd600',
-  '#aacc00', '#38b000', '#0fb5a0', '#00b4d8', '#4cc9f0', '#3a86ff', '#4361ee',
-  '#7b2d8b', '#9d4edd', '#c77dff', '#ff48c4',
+const REVIEW_CATS = ['characters', 'locations', 'items', 'scenes', 'timeline', 'wiki', 'world', 'glossary', 'spellings', 'canon', 'flags', 'questions', 'notes']
+const DASH_SEARCH_SCOPES = [
+  ['all', '🌐 All Tabs'],
+  ['characters', '👤 Characters'],
+  ['wiki', '📖 Wiki'],
+  ['glossary', '📚 Glossary'],
+  ['locations', '📍 Locations'],
+  ['world', '🌍 World'],
+  ['scenes', '🎬 Scenes'],
+  ['timeline', '⏳ Timeline'],
+  ['manuscript', '📜 Manuscript'],
+  ['flags', '🚩 Flags'],
+  ['questions', '❓ Questions'],
+  ['canon', '✦ Canon'],
+  ['spellings', '🔤 Spellings'],
+  ['notes', '📝 Notes'],
 ]
 
-const REVIEW_CATS = ['characters', 'locations', 'items', 'scenes', 'timeline', 'wiki', 'world', 'glossary', 'spellings', 'canon', 'flags', 'questions', 'notes']
-const rc = i => RAINBOW[i % RAINBOW.length]
+function getEntryName(e) {
+  return e.name || e.title || e.display_name || e.word || e.term || e.text?.slice(0, 50) || '(unnamed)'
+}
 
-export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch }) {
-  const { db: data } = db
-  const [headerImg, setHeaderImg] = useState(() => {
-    try { return db.settings?.dashboard_header_image || '' } catch { return '' }
-  })
-  const imgRef = useRef(null)
+function getCategoryEntries(data, cat) {
+  if (cat === 'glossary') return (data.wiki || []).filter(e => e.is_glossary)
+  return data[cat] || []
+}
+
+function getCategoryCount(data, cat) {
+  return getCategoryEntries(data, cat).length
+}
+
+export default function Dashboard({ db, goTo, crossLink }) {
+  const data = db.db
+  const [searchScope, setSearchScope] = useState('all')
+  const [dashSearch, setDashSearch] = useState('')
 
   let tot = 0
   let lk = 0
@@ -31,49 +51,41 @@ export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch
   const fl = (data.flags || []).length
 
   Object.keys(CATS).forEach(c => {
-    if (c === 'flags' || c === 'dashboard' || !data[c]) return
-    tot += data[c].length
-    data[c].forEach(e => {
+    if (c === 'flags' || c === 'dashboard') return
+    const entries = getCategoryEntries(data, c)
+    if (!Array.isArray(entries) || !entries.length) return
+    tot += entries.length
+    entries.forEach(e => {
       if (e.status === 'locked') lk++
       if (e.status === 'provisional') pv++
       if (e.status === 'open') op++
     })
   })
 
-  const recent = []
-  Object.entries(data).forEach(([cat, entries]) => {
-    if (!Array.isArray(entries) || !CATS[cat]) return
-    entries.forEach(e => {
-      const ts = e.updated_at || e.updated || e.created_at || e.created
-      if (ts) recent.push({ cat, name: e.name || e.title || e.display_name || e.word || '(unnamed)', ts, id: e.id })
+  const recent = useMemo(() => {
+    const rows = []
+    Object.keys(CATS).forEach(cat => {
+      const entries = getCategoryEntries(data, cat)
+      if (!Array.isArray(entries)) return
+      entries.forEach(e => {
+        const ts = e.updated_at || e.updated || e.created_at || e.created
+        if (!ts) return
+        rows.push({ cat, name: getEntryName(e), ts, id: e.id })
+      })
     })
-  })
-  recent.sort((a, b) => new Date(b.ts) - new Date(a.ts))
+    rows.sort((a, b) => new Date(b.ts || 0) - new Date(a.ts || 0))
+    return rows
+  }, [data])
 
   let reviewCount = 0
   const reviewItems = []
   REVIEW_CATS.forEach(cat => {
-    if (cat === 'glossary') {
-      ;(data.wiki || []).forEach(e => {
-        if (e.auto_imported === true && e.is_glossary) {
-          reviewCount++
-          reviewItems.push({
-            cat: 'glossary',
-            name: e.title || e.name || '(unnamed)',
-            id: e.id,
-            source: e.source || 'unknown',
-            updated: e.updated || e.updated_at || e.created_at || e.created,
-          })
-        }
-      })
-      return
-    }
-    ;(data[cat] || []).forEach(e => {
-      if (e.auto_imported === true) {
+    getCategoryEntries(data, cat).forEach(e => {
+      if (e.auto_imported === true || e.source === 'sticky' || e.source === 'session-import') {
         reviewCount++
         reviewItems.push({
           cat,
-          name: e.name || e.title || e.term || e.word || e.display_name || e.text?.slice(0, 50) || '(unnamed)',
+          name: getEntryName(e),
           id: e.id,
           source: e.source || 'unknown',
           updated: e.updated || e.updated_at || e.created_at || e.created,
@@ -85,17 +97,35 @@ export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch
 
   const flags = (data.flags || []).slice(0, 14)
 
-  function handleHeaderImg(e) {
-    const file = e.target.files?.[0]
-    if (!file) return
-    const reader = new FileReader()
-    reader.onload = ev => {
-      const url = ev.target.result
-      setHeaderImg(url)
-      db.saveSetting('dashboard_header_image', url)
-    }
-    reader.readAsDataURL(file)
-  }
+  const searchResults = useMemo(() => {
+    if (!dashSearch.trim()) return []
+    const q = dashSearch.toLowerCase()
+    const cats = searchScope === 'all' ? DASH_SEARCH_SCOPES.slice(1).map(s => s[0]) : [searchScope]
+    const results = []
+    cats.forEach(cat => {
+      getCategoryEntries(data, cat).forEach(e => {
+        const hay = [
+          e.name, e.title, e.display_name, e.word, e.term, e.text,
+          e.summary, e.notes, e.detail, e.content, e.definition, e.significance,
+        ].filter(Boolean).join(' ').toLowerCase()
+        if (hay.includes(q)) {
+          results.push({
+            cat,
+            id: e.id,
+            name: getEntryName(e),
+          })
+        }
+      })
+    })
+    return results.slice(0, 40)
+  }, [dashSearch, searchScope, data])
+
+  const panelHead = (icon, label, color, count) => (
+    <div style={{ fontSize: '0.77em', fontWeight: 700, color, textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8, paddingBottom: 4, borderBottom: '1px solid var(--brd)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', minWidth: 0, overflow: 'hidden' }}>
+      <span style={{ whiteSpace: 'nowrap' }}>{icon} {label}</span>
+      {count != null && <span style={{ color: 'var(--mut)', fontWeight: 400, flexShrink: 0 }}>{count}</span>}
+    </div>
+  )
 
   const panelRow = (item, i, color, onClick) => (
     <div
@@ -111,29 +141,32 @@ export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch
     </div>
   )
 
-  const panelHead = (icon, label, color, count) => (
-    <div style={{ fontSize: '0.77em', fontWeight: 700, color, textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8, paddingBottom: 4, borderBottom: '1px solid var(--brd)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', minWidth: 0, overflow: 'hidden' }}>
-      <span style={{ whiteSpace: 'nowrap' }}>{icon} {label}</span>
-      {count != null && <span style={{ color: 'var(--mut)', fontWeight: 400, flexShrink: 0 }}>{count}</span>}
-    </div>
-  )
-
-  let searchHits = []
-  if ((navSearch || '').trim().length > 1) {
-    const q = (navSearch || '').trim().toLowerCase()
-    Object.entries(data).forEach(([cat, entries]) => {
-      if (!Array.isArray(entries) || !CATS[cat]) return
-      entries.forEach(entry => {
-        const name = entry.name || entry.title || entry.display_name || entry.word || ''
-        if (name.toLowerCase().includes(q) || JSON.stringify(entry).toLowerCase().includes(q)) {
-          searchHits.push({ cat, name: name || '(unnamed)', id: entry.id })
-        }
-      })
-    })
-  }
-
   return (
     <div style={{ width: '100%', minWidth: 0 }}>
+      {searchResults.length === 0 && dashSearch && (
+        <div style={{ padding: 10, fontSize: '0.85em', color: 'var(--mut)' }}>No matches.</div>
+      )}
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 14 }}>
+        <select value={searchScope} onChange={e => setSearchScope(e.target.value)}
+          style={{ padding: '6px 10px', fontSize: '0.85em', background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
+          {DASH_SEARCH_SCOPES.map(([k, l]) => <option key={k} value={k}>{l}</option>)}
+        </select>
+        <input type="text" value={dashSearch} onChange={e => setDashSearch(e.target.value)}
+          placeholder={`Search ${searchScope === 'all' ? 'everything' : searchScope}...`}
+          style={{ flex: 1, padding: '6px 10px', fontSize: '0.92em', background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }} />
+      </div>
+      {searchResults.length > 0 && (
+        <div style={{ marginBottom: 14, maxHeight: 300, overflowY: 'auto', border: '1px solid var(--brd)', borderRadius: 6, padding: 8, background: 'var(--card)' }}>
+          {searchResults.map((r, i) => (
+            <div key={`${r.cat}-${r.id}-${i}`} onClick={() => { crossLink(r.cat, r.id); setDashSearch('') }}
+              style={{ padding: '4px 8px', fontSize: '0.85em', cursor: 'pointer', borderLeft: `3px solid ${TAB_RAINBOW[r.cat] || 'var(--cc)'}`, marginBottom: 2 }}>
+              <span style={{ color: TAB_RAINBOW[r.cat] }}>{CATS[r.cat]?.i}</span> {r.name}
+              <span style={{ fontSize: '0.77em', color: 'var(--mut)', marginLeft: 8 }}>({r.cat})</span>
+            </div>
+          ))}
+        </div>
+      )}
+
       <div style={{ display: 'flex', justifyContent: 'center', gap: 6, flexWrap: 'wrap', alignItems: 'center', marginBottom: 14 }}>
         <div className="dash-card" style={{ minWidth: 80, textAlign: 'center' }}>
           <div className="dash-num" style={{ color: 'var(--so)' }}>{op}</div>
@@ -159,45 +192,22 @@ export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch
           <div className="dash-label">🔍 Review Queue</div>
         </div>
         <div className="dash-card" onClick={() => goTo('flags')} style={{ cursor: 'pointer', minWidth: 100, textAlign: 'center' }}>
-          <div className="dash-num" style={{ color: 'var(--cfl)' }}>{fl}</div>
+          <div className="dash-num" style={{ color: TAB_RAINBOW.flags }}>{fl}</div>
           <div className="dash-label">🚩 Flags</div>
         </div>
         <div className="dash-card" onClick={() => goTo('questions')} style={{ cursor: 'pointer', minWidth: 100, textAlign: 'center' }}>
-          <div className="dash-num" style={{ color: 'var(--cq)' }}>{(data.questions || []).filter(q => q.status === 'open').length}</div>
+          <div className="dash-num" style={{ color: TAB_RAINBOW.questions }}>{(data.questions || []).filter(q => q.status === 'open').length}</div>
           <div className="dash-label">❓ Questions</div>
         </div>
       </div>
 
-      <div style={{ marginBottom: 14 }}>
-        {searchHits.length > 0 && (
-          <div style={{ marginTop: 6, background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 8, maxHeight: 220, overflowY: 'auto' }}>
-            <div style={{ fontSize: '0.77em', color: 'var(--mut)', padding: '5px 10px', borderBottom: '1px solid var(--brd)' }}>
-              {searchHits.length} result{searchHits.length !== 1 ? 's' : ''} - click to open entry
-            </div>
-            {searchHits.slice(0, 30).map((h, i) => (
-              <div
-                key={h.id || i}
-                onClick={() => { crossLink(h.cat, h.id); setNavSearch && setNavSearch('') }}
-                style={{ display: 'flex', justifyContent: 'space-between', padding: '5px 10px', borderBottom: '1px solid var(--brd)', cursor: 'pointer', background: i % 2 === 0 ? 'transparent' : 'rgba(255,255,255,.02)' }}
-                onMouseEnter={e => { e.currentTarget.style.background = 'rgba(255,255,255,.06)' }}
-                onMouseLeave={e => { e.currentTarget.style.background = i % 2 === 0 ? 'transparent' : 'rgba(255,255,255,.02)' }}
-              >
-                <span style={{ fontSize: '0.92em' }}>{h.name}</span>
-                <span style={{ fontSize: '0.77em', color: TAB_RAINBOW[h.cat] || 'var(--mut)' }}>{CATS[h.cat]?.i} {CATS[h.cat]?.l}</span>
-              </div>
-            ))}
-            {searchHits.length > 30 && <div style={{ fontSize: '0.77em', color: 'var(--mut)', padding: '5px 10px' }}>...and {searchHits.length - 30} more.</div>}
-          </div>
-        )}
-      </div>
-
       <div style={{ display: 'flex', flexDirection: 'row', gap: 12, alignItems: 'flex-start', width: '100%', minWidth: 0 }}>
         <div style={{ flexShrink: 0, minWidth: 140, width: 'max-content', maxWidth: 220, borderRight: '2px solid var(--brd)', paddingRight: 10, marginRight: 2 }}>
-          {TAB_LIST.map((k, i) => {
+          {TAB_LIST.map(k => {
             const c = CATS[k]
             if (!c) return null
-            const count = k === 'flags' ? fl : (data[k] || []).length
-            const color = TAB_RAINBOW[k] || rc(i)
+            const count = k === 'flags' ? fl : getCategoryCount(data, k)
+            const color = TAB_RAINBOW[k] || 'var(--cc)'
             return (
               <div
                 key={k}
@@ -217,28 +227,23 @@ export default function Dashboard({ db, goTo, crossLink, navSearch, setNavSearch
           {panelHead('⏱', 'Recent', 'var(--tx)', null)}
           {recent.length === 0
             ? <div style={{ fontSize: '0.85em', color: 'var(--mut)', fontStyle: 'italic' }}>No recent entries</div>
-            : recent.slice(0, 14).map((r, i) => panelRow({ ...r, detail: null }, i, TAB_RAINBOW[r.cat] || 'var(--cc)', () => crossLink(r.cat, r.id)))
-          }
+            : recent.slice(0, 14).map((r, i) => panelRow({ ...r, detail: null }, i, TAB_RAINBOW[r.cat] || 'var(--cc)', () => crossLink(r.cat, r.id)))}
         </div>
 
         <div style={{ flex: '1 1 0', minWidth: 140, overflow: 'hidden' }}>
           {panelHead('🔍', 'Review Queue', 'var(--cc)', reviewCount)}
           {reviewItems.length === 0
             ? <div style={{ fontSize: '0.85em', color: 'var(--mut)', fontStyle: 'italic' }}>Nothing to review</div>
-            : reviewItems.slice(0, 14).map((r, i) => panelRow({ ...r, detail: r.source === 'sticky' ? '📌 from sticky' : '📥 from session import' }, i, TAB_RAINBOW[r.cat] || 'var(--cc)', () => crossLink(r.cat, r.id)))
-          }
+            : reviewItems.slice(0, 14).map((r, i) => panelRow({ ...r, detail: r.source === 'sticky' ? '📌 from sticky' : '📥 from session import' }, i, TAB_RAINBOW[r.cat] || 'var(--cc)', () => crossLink(r.cat, r.id)))}
         </div>
 
         <div style={{ flex: '1 1 0', minWidth: 140, overflow: 'hidden' }}>
-          {panelHead('🚩', 'Flags', 'var(--cfl)', fl)}
+          {panelHead('🚩', 'Flags', TAB_RAINBOW.flags, fl)}
           {flags.length === 0
             ? <div style={{ fontSize: '0.85em', color: 'var(--mut)', fontStyle: 'italic' }}>No flags</div>
-            : flags.map((f, i) => panelRow({ ...f, detail: f.detail }, i, 'var(--cfl)', () => crossLink('flags', f.id)))
-          }
+            : flags.map((f, i) => panelRow({ ...f, detail: f.detail }, i, TAB_RAINBOW.flags, () => crossLink('flags', f.id)))}
         </div>
       </div>
-
-      <input ref={imgRef} type="file" accept="image/*" style={{ display: 'none' }} onChange={handleHeaderImg} />
     </div>
   )
 }

--- a/src/tabs/Eras.jsx
+++ b/src/tabs/Eras.jsx
@@ -51,15 +51,15 @@ function EditModal({ item, type, onSave, onClose }) {
   function set(k, v) { setForm(p => ({ ...p, [k]: v })) }
   const inp = (k, label, num) => (
     <div style={{ marginBottom: 10 }}>
-      <label style={{ fontSize: 10, color: 'var(--mut)', display: 'block', marginBottom: 3 }}>{label}</label>
+      <label style={{ fontSize: '0.77em', color: 'var(--mut)', display: 'block', marginBottom: 3 }}>{label}</label>
       <input type={num ? 'number' : 'text'} value={form[k] ?? ''} onChange={e => set(k, num ? parseFloat(e.target.value) : e.target.value)}
-        style={{ width: '100%', fontSize: 11, padding: '5px 8px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', boxSizing: 'border-box' }} />
+        style={{ width: '100%', fontSize: '0.85em', padding: '5px 8px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', boxSizing: 'border-box' }} />
     </div>
   )
   return (
     <div style={{ position: 'fixed', inset: 0, zIndex: 400, background: 'rgba(0,0,0,.8)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20 }}>
       <div style={{ background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 12, padding: 20, width: '100%', maxWidth: 420, maxHeight: '90vh', overflowY: 'auto' }}>
-        <div style={{ fontFamily: "'Cinzel',serif", fontSize: 14, color: 'var(--cca)', marginBottom: 14 }}>
+        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.08em', color: 'var(--cca)', marginBottom: 14 }}>
           ✎ Edit {type === 'timeline' ? 'Timeline Entry' : 'Era Span'}
         </div>
         {type === 'timeline' ? (
@@ -81,7 +81,7 @@ function EditModal({ item, type, onSave, onClose }) {
           <button className="btn btn-outline btn-sm" onClick={onClose}>Cancel</button>
           <button className="btn btn-primary btn-sm" style={{ background: 'var(--cca)', color: '#000' }} onClick={() => { onSave(form); onClose() }}>Save</button>
         </div>
-        <div style={{ fontSize: 9, color: 'var(--mut)', marginTop: 10 }}>
+        <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 10 }}>
           Edits are saved to your account and will persist across sessions.
         </div>
       </div>
@@ -129,7 +129,7 @@ export default function Eras({ db }) {
     <div>
       <div style={{ textAlign: 'center', padding: '16px 0 8px' }}>
         <div style={{ fontFamily: "'Cinzel', serif", fontSize: 17, color: 'var(--cca)' }}>⧖ Eras & Dating</div>
-        <div style={{ fontSize: 10, color: 'var(--mut)' }}>HC 320 = 1554 AD · 8.52 Lajen years = 1 Mnaerah year · All dates EXPLORATORY</div>
+        <div style={{ fontSize: '0.77em', color: 'var(--mut)' }}>HC 320 = 1554 AD · 8.52 Lajen years = 1 Mnaerah year · All dates EXPLORATORY</div>
       </div>
 
       {/* Era spans */}
@@ -137,27 +137,27 @@ export default function Eras({ db }) {
         {spans.map((s, i) => (
           <div key={s.name} style={{ background: 'var(--card)', border: '1px solid var(--brd)', borderTop: `3px solid ${s.col}`, borderRadius: 'var(--r)', padding: 10, textAlign: 'center', position: 'relative' }}>
             <button onClick={() => { setEditItem(s); setEditType('span'); setEditIdx(i) }}
-              style={{ position: 'absolute', top: 6, right: 6, background: 'none', border: 'none', color: 'var(--mut)', fontSize: 12, cursor: 'pointer', padding: '2px 5px', borderRadius: 4 }}
+              style={{ position: 'absolute', top: 6, right: 6, background: 'none', border: 'none', color: 'var(--mut)', fontSize: '0.92em', cursor: 'pointer', padding: '2px 5px', borderRadius: 4 }}
               title="Edit">✎</button>
-            <div style={{ fontFamily: "'Cinzel', serif", fontSize: 13, color: s.col }}>{s.name}</div>
+            <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1em', color: s.col }}>{s.name}</div>
             <div style={{ fontSize: 18, fontWeight: 700, margin: '4px 0' }}>{s.ly}</div>
-            <div style={{ fontSize: 11, color: 'var(--dim)' }}>{s.my}</div>
-            <div style={{ fontSize: 9, color: 'var(--mut)', marginTop: 2 }}>{s.desc}</div>
+            <div style={{ fontSize: '0.85em', color: 'var(--dim)' }}>{s.my}</div>
+            <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 2 }}>{s.desc}</div>
           </div>
         ))}
       </div>
 
       {/* Visual timeline */}
       <div style={{ background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 'var(--rl)', padding: 16, marginBottom: 16 }}>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: 14, color: 'var(--cca)', marginBottom: 12 }}>Timeline</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.08em', color: 'var(--cca)', marginBottom: 12 }}>Timeline</div>
         <div style={{ position: 'relative', paddingLeft: 90 }}>
           {timeline.map((e, i) => {
             const isLast = i === timeline.length - 1
             return (
               <div key={i} style={{ display: 'flex', minHeight: i===0?48:56, position: 'relative' }}>
-                <div style={{ position: 'absolute', left: -90, width: 80, textAlign: 'right', paddingRight: 12, fontSize: 10 }}>
+                <div style={{ position: 'absolute', left: -90, width: 80, textAlign: 'right', paddingRight: 12, fontSize: '0.77em' }}>
                   <div style={{ fontWeight: 600 }}>{e.ly}</div>
-                  <div style={{ color: 'var(--mut)', fontSize: 9 }}>{e.my}</div>
+                  <div style={{ color: 'var(--mut)', fontSize: '0.69em' }}>{e.my}</div>
                 </div>
                 <div style={{ position: 'relative', width: 14, flexShrink: 0 }}>
                   <div style={{ width: 10, height: 10, borderRadius: '50%', background: e.col, position: 'absolute', top: 3, left: 2, zIndex: 1 }} />
@@ -165,11 +165,11 @@ export default function Eras({ db }) {
                 </div>
                 <div style={{ padding: '0 0 12px 8px', flex: 1, display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
                   <div>
-                    <div style={{ fontSize: 12, fontWeight: 600, color: e.col }}>{e.label}</div>
-                    <div style={{ fontSize: 11, color: 'var(--dim)', marginTop: 1 }}>{e.desc}</div>
+                    <div style={{ fontSize: '0.92em', fontWeight: 600, color: e.col }}>{e.label}</div>
+                    <div style={{ fontSize: '0.85em', color: 'var(--dim)', marginTop: 1 }}>{e.desc}</div>
                   </div>
                   <button onClick={() => { setEditItem(e); setEditType('timeline'); setEditIdx(i) }}
-                    style={{ background: 'none', border: 'none', color: 'var(--mut)', fontSize: 11, cursor: 'pointer', flexShrink: 0, padding: '2px 6px' }}>✎</button>
+                    style={{ background: 'none', border: 'none', color: 'var(--mut)', fontSize: '0.85em', cursor: 'pointer', flexShrink: 0, padding: '2px 6px' }}>✎</button>
                 </div>
               </div>
             )
@@ -179,15 +179,15 @@ export default function Eras({ db }) {
 
       {/* Conversion table */}
       <div style={{ background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 'var(--rl)', padding: 16, marginBottom: 16 }}>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: 14, color: 'var(--cca)', marginBottom: 4 }}>Conversion Table</div>
-        <div style={{ fontSize: 9, color: 'var(--mut)', marginBottom: 8 }}>Anchor: HC 320 = 1554 AD. Earth-history sections collapsed by default.</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.08em', color: 'var(--cca)', marginBottom: 4 }}>Conversion Table</div>
+        <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginBottom: 8 }}>Anchor: HC 320 = 1554 AD. Earth-history sections collapsed by default.</div>
         <div style={{ overflowX: 'auto' }}>
           {ERA_TABLE.map(cat => (
             <details key={cat.cat} open={lajenCore.has(cat.cat)} style={{ marginBottom: 4 }}>
-              <summary style={{ fontSize: 10, fontWeight: 700, color: 'var(--cca)', padding: '6px 4px', cursor: 'pointer', userSelect: 'none', textTransform: 'uppercase', letterSpacing: '.06em', listStyle: 'none', display: 'flex', alignItems: 'center', gap: 6 }}>
-                {cat.cat} <span style={{ fontSize: 9, color: 'var(--mut)', fontWeight: 400, textTransform: 'none' }}>({cat.rows.length} entries)</span>
+              <summary style={{ fontSize: '0.77em', fontWeight: 700, color: 'var(--cca)', padding: '6px 4px', cursor: 'pointer', userSelect: 'none', textTransform: 'uppercase', letterSpacing: '.06em', listStyle: 'none', display: 'flex', alignItems: 'center', gap: 6 }}>
+                {cat.cat} <span style={{ fontSize: '0.69em', color: 'var(--mut)', fontWeight: 400, textTransform: 'none' }}>({cat.rows.length} entries)</span>
               </summary>
-              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 10, marginBottom: 4 }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.77em', marginBottom: 4 }}>
                 <thead>
                   <tr style={{ borderBottom: '1px solid var(--brd)' }}>
                     {['Mnaerah','Event','MY before 1554','HC Date','Lajen clock','Mnaerah clock'].map(h => (

--- a/src/tabs/Eras.jsx
+++ b/src/tabs/Eras.jsx
@@ -128,7 +128,7 @@ export default function Eras({ db }) {
   return (
     <div>
       <div style={{ textAlign: 'center', padding: '16px 0 8px' }}>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: 17, color: 'var(--cca)' }}>⧖ Eras & Dating</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.31em', color: 'var(--cca)' }}>⧖ Eras & Dating</div>
         <div style={{ fontSize: '0.77em', color: 'var(--mut)' }}>HC 320 = 1554 AD · 8.52 Lajen years = 1 Mnaerah year · All dates EXPLORATORY</div>
       </div>
 
@@ -140,7 +140,7 @@ export default function Eras({ db }) {
               style={{ position: 'absolute', top: 6, right: 6, background: 'none', border: 'none', color: 'var(--mut)', fontSize: '0.92em', cursor: 'pointer', padding: '2px 5px', borderRadius: 4 }}
               title="Edit">✎</button>
             <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1em', color: s.col }}>{s.name}</div>
-            <div style={{ fontSize: 18, fontWeight: 700, margin: '4px 0' }}>{s.ly}</div>
+            <div style={{ fontSize: '1.38em', fontWeight: 700, margin: '4px 0' }}>{s.ly}</div>
             <div style={{ fontSize: '0.85em', color: 'var(--dim)' }}>{s.my}</div>
             <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 2 }}>{s.desc}</div>
           </div>

--- a/src/tabs/FamilyTree.jsx
+++ b/src/tabs/FamilyTree.jsx
@@ -1,8 +1,10 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import Modal from '../components/common/Modal'
-import { uid } from '../constants'
+import { TAB_RAINBOW, uid } from '../constants'
 
 // ── Built-in relationship types ─────────────────────────────────
+const tabColor = TAB_RAINBOW['familytree'] || '#aaaaaa'
+
 const BUILTIN_EDGE_TYPES = [
   'Parent/Child', 'Married', 'Romantic Partner', 'Other Parent',
   'Sibling', 'Half-sibling', 'Step-sibling',
@@ -570,7 +572,7 @@ function RelationshipWeb({ nodes, edges, allEdgeColors, allNodeColors, editMode,
             <div style={{ display:'flex', gap:6, marginTop:8 }}>
               <button className="btn btn-sm btn-outline" style={{ fontSize: '0.77em' }}
                 onClick={() => setNodeModal(sel)}>✎ Edit</button>
-              <button className="btn btn-sm btn-outline" style={{ fontSize: '0.77em', color:'var(--cl)', borderColor:'var(--cl)' }}
+              <button className="btn btn-sm btn-outline" style={{ fontSize: '0.77em', color:tabColor, borderColor:tabColor }}
                 onClick={() => setEdgeModal({ from: sel.id })}>+ Add Relation</button>
             </div>
           )}
@@ -765,16 +767,16 @@ export default function FamilyTree({ db }) {
     <div>
       {/* ── Toolbar ── */}
       <div className="tbar" style={{ flexWrap: 'wrap', gap: 6 }}>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.08em', color: 'var(--cl)' }}>🌳 Family Tree</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.08em', color: tabColor }}>🌳 Family Tree</div>
         <div style={{ display:'flex', gap:3 }}>
-          {[['🌳 Tree','tree'],['🕸 Web','web']].map(([l,v]) => (
-            <button key={v} onClick={() => setViewMode(v)}
-              style={{ fontSize: '0.77em', padding:'3px 10px', borderRadius:10,
-                background: viewMode===v ? 'var(--cl)' : 'none',
+            {[['🌳 Tree','tree'],['🕸 Web','web']].map(([l,v]) => (
+              <button key={v} onClick={() => setViewMode(v)}
+                style={{ fontSize: '0.77em', padding:'3px 10px', borderRadius:10,
+                background: viewMode===v ? tabColor : 'none',
                 color: viewMode===v ? '#000' : 'var(--dim)',
-                border: `1px solid ${viewMode===v ? 'var(--cl)' : 'var(--brd)'}`,
+                border: `1px solid ${viewMode===v ? tabColor : 'var(--brd)'}`,
                 cursor:'pointer' }}>{l}</button>
-          ))}
+            ))}
         </div>
         <button className="btn btn-sm btn-outline" style={{ color: editMode ? 'var(--cc)' : 'var(--dim)', borderColor: editMode ? 'var(--cc)' : 'var(--brd)' }} onClick={() => setEditMode(v => !v)}>
           {editMode ? '✓ Editing' : '✎ Edit Mode'}
@@ -783,7 +785,7 @@ export default function FamilyTree({ db }) {
           <button className="btn btn-primary btn-sm" style={{ background: 'var(--cc)' }} onClick={() => setNodeModal({})}>+ Person</button>
           <button className="btn btn-sm btn-outline" style={{ color: 'var(--cca)', borderColor: 'var(--cca)' }} onClick={() => setEdgeModal({})}>+ Relation</button>
         </>}
-        <button className="btn btn-sm btn-outline" style={{ color: 'var(--cl)', borderColor: 'var(--cl)' }} onClick={syncChars} title="Adds new characters without removing existing edits">
+        <button className="btn btn-sm btn-outline" style={{ color: tabColor, borderColor: tabColor }} onClick={syncChars} title="Adds new characters without removing existing edits">
           ⟳ Sync Characters
         </button>
         {unknownEdges.length > 0 && (
@@ -837,7 +839,7 @@ export default function FamilyTree({ db }) {
             Click <strong>⟳ Sync Characters</strong> to auto-populate, or add people manually in Edit Mode.
           </p>
           <div style={{ display:'flex', gap:10, justifyContent:'center', flexWrap:'wrap' }}>
-            <button className="btn btn-primary" style={{ background:'var(--cl)', color:'#000' }} onClick={syncChars}>⟳ Sync Characters</button>
+            <button className="btn btn-primary" style={{ background:tabColor, color:'#000' }} onClick={syncChars}>⟳ Sync Characters</button>
             <button className="btn btn-outline" style={{ color:'var(--cc)', borderColor:'var(--cc)' }} onClick={() => { setEditMode(true); setNodeModal({}) }}>+ Add Manually</button>
           </div>
         </div>
@@ -928,7 +930,7 @@ export default function FamilyTree({ db }) {
       )}
 
       {/* ── Modals ── */}
-      <Modal open={!!nodeModal} onClose={() => setNodeModal(null)} title={nodeModal?.id ? 'Edit Person' : 'Add Person'} color="var(--cl)">
+      <Modal open={!!nodeModal} onClose={() => setNodeModal(null)} title={nodeModal?.id ? 'Edit Person' : 'Add Person'} color={tabColor}>
         {nodeModal && <NodeForm node={nodeModal} onSave={saveNode} onCancel={() => setNodeModal(null)} db={db} nodeTypes={allNodeTypes}
           onAddNodeType={t => saveCustom(undefined, [...customNodeTypes, t], undefined, undefined)} />}
       </Modal>
@@ -1020,7 +1022,7 @@ function NodeForm({ node, onSave, onCancel, db, nodeTypes, onAddNodeType }) {
       <div className="field"><label>Notes</label><textarea value={form.notes} onChange={s('notes')} /></div>
       <div className="modal-actions">
         <button className="btn btn-outline" onClick={onCancel}>Cancel</button>
-        <button className="btn btn-primary" style={{background:'var(--cl)',color:'#000'}} onClick={handleSave}>{node.id?'Save Changes':'Add Person'}</button>
+        <button className="btn btn-primary" style={{background:tabColor,color:'#000'}} onClick={handleSave}>{node.id?'Save Changes':'Add Person'}</button>
       </div>
     </>
   )

--- a/src/tabs/Flags.jsx
+++ b/src/tabs/Flags.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
 import Modal from '../components/common/Modal'
-import { uid } from '../constants'
+import { TAB_RAINBOW, uid } from '../constants'
 import { scrollAndFlashEntry } from '../components/common/entryNav'
 
 export default function Flags({ db }) {
+  const tabColor = TAB_RAINBOW['flags'] || '#aaaaaa'
   const flags = db.db.flags || []
   const [filter, setFilter] = useState('active')
   const [colCount, setColCount] = useState(() => parseInt(db.getSetting?.('fl_cols') || '2'))
@@ -63,10 +64,10 @@ export default function Flags({ db }) {
   return (
     <div>
       <div className="tbar">
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.15em', color: 'var(--cfl)' }}>🚩 Flags & Review</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.15em', color: tabColor }}>🚩 Flags & Review</div>
         <div style={{ display: 'flex', gap: 3 }}>
           {[['XS', 8], ['S', 5], ['M', 3], ['L', 2], ['XL', 1]].map(([l, n]) => (
-            <button key={l} onClick={() => saveColCount(n)} style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, background: colCount === n ? 'var(--cfl)' : 'none', color: colCount === n ? '#000' : 'var(--dim)', border: `1px solid ${colCount === n ? 'var(--cfl)' : 'var(--brd)'}`, cursor: 'pointer' }}>{l}</button>
+            <button key={l} onClick={() => saveColCount(n)} style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, background: colCount === n ? tabColor : 'none', color: colCount === n ? '#000' : 'var(--dim)', border: `1px solid ${colCount === n ? tabColor : 'var(--brd)'}`, cursor: 'pointer' }}>{l}</button>
           ))}
           <button onClick={toggleDividers} style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, marginLeft: 8, background: dividers ? 'rgba(255,255,255,.08)' : 'none', color: dividers ? 'var(--tx)' : 'var(--mut)', border: '1px solid var(--brd)', cursor: 'pointer' }}>{dividers ? '┃ on' : '┃ off'}</button>
         </div>
@@ -75,12 +76,12 @@ export default function Flags({ db }) {
             📥 Auto-imported ({autoCount})
           </button>
         )}
-        <button className="btn btn-primary btn-sm" style={{ background: 'var(--cfl)', color: '#000' }} onClick={() => { setForm({ name: '', priority: 'high', detail: '' }); setModalOpen(true) }}>+ Add Flag</button>
+        <button className="btn btn-primary btn-sm" style={{ background: tabColor, color: '#000' }} onClick={() => { setForm({ name: '', priority: 'high', detail: '' }); setModalOpen(true) }}>+ Add Flag</button>
       </div>
 
       <div className="tbar" style={{ paddingTop: 0 }}>
         <div className="filter-group">
-          {[['active', 'Active'], ['resolved', 'Resolved'], ['all', 'All']].map(([k, l]) => <button key={k} className={`fp ${filter === k ? 'active' : ''}`} style={{ color: 'var(--cfl)' }} onClick={() => setFilter(k)}>{l}</button>)}
+          {[['active', 'Active'], ['resolved', 'Resolved'], ['all', 'All']].map(([k, l]) => <button key={k} className={`fp ${filter === k ? 'active' : ''}`} style={{ color: tabColor }} onClick={() => setFilter(k)}>{l}</button>)}
         </div>
         <span style={{ fontSize: '0.77em', color: 'var(--mut)', marginLeft: 8 }}>{flags.filter(f => !f.resolved).length} active · {flags.filter(f => f.resolved).length} resolved</span>
       </div>
@@ -103,7 +104,7 @@ export default function Flags({ db }) {
                   ? <button className="btn btn-sm btn-outline" style={{ color: 'var(--sl)', borderColor: 'var(--sl)' }} onClick={() => resolve(f)}>✓ Resolve</button>
                   : <button className="btn btn-sm btn-outline" style={{ color: 'var(--sp)', borderColor: 'var(--sp)' }} onClick={() => reopen(f)}>↩ Reopen</button>
                 }
-                <button className="btn btn-sm btn-outline" style={{ color: 'var(--cfl)', borderColor: 'var(--cfl)' }} onClick={() => { setForm(f); setModalOpen(true) }}>✎ Edit</button>
+                <button className="btn btn-sm btn-outline" style={{ color: tabColor, borderColor: tabColor }} onClick={() => { setForm(f); setModalOpen(true) }}>✎ Edit</button>
                 <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544' }} onClick={() => setConfirmId(f.id)}>✕ Delete</button>
               </div>
             </div>
@@ -111,13 +112,13 @@ export default function Flags({ db }) {
         })}
       </div>
 
-      <Modal open={modalOpen} onClose={() => setModalOpen(false)} title={form.id ? 'Edit Flag' : 'Add Flag'} color="var(--cfl)">
+      <Modal open={modalOpen} onClose={() => setModalOpen(false)} title={form.id ? 'Edit Flag' : 'Add Flag'} color={tabColor}>
         <div className="field"><label>Description *</label><input value={form.name || ''} onChange={e => setForm(p => ({ ...p, name: e.target.value }))} placeholder="What needs attention?" /></div>
         <div className="field"><label>Priority</label><select value={form.priority || 'high'} onChange={e => setForm(p => ({ ...p, priority: e.target.value }))}>{['urgent', 'high', 'medium', 'low'].map(p => <option key={p} value={p}>{p}</option>)}</select></div>
         <div className="field"><label>Detail</label><textarea value={form.detail || ''} onChange={e => setForm(p => ({ ...p, detail: e.target.value }))} placeholder="Optional detail..." /></div>
         <div className="modal-actions">
           <button className="btn btn-outline" onClick={() => setModalOpen(false)}>Cancel</button>
-          <button className="btn btn-primary" style={{ background: 'var(--cfl)', color: '#000' }} onClick={saveFlag}>{form.id ? 'Save Flag' : 'Add Flag'}</button>
+          <button className="btn btn-primary" style={{ background: tabColor, color: '#000' }} onClick={saveFlag}>{form.id ? 'Save Flag' : 'Add Flag'}</button>
         </div>
       </Modal>
 

--- a/src/tabs/Glossary.jsx
+++ b/src/tabs/Glossary.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
 import FilterPopup from '../components/common/FilterPopup'
 import AlphabetJumpBar from '../components/common/AlphabetJumpBar'
+import { TAB_RAINBOW } from '../constants'
 import { scrollAndFlashEntry } from '../components/common/entryNav'
 
 const GLOSSARY_CATS = ['Languages', 'Lore', 'Cosmology', 'Power System', 'Cultures', 'Religions', 'Factions', 'Geography']
+const tabColor = TAB_RAINBOW['glossary'] || '#aaaaaa'
 
 export default function Glossary({ db, goTo, goToWiki, navSearch }) {
   const [search, setSearch] = useState(navSearch || '')
@@ -63,7 +65,7 @@ export default function Glossary({ db, goTo, goToWiki, navSearch }) {
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12, flexWrap: 'wrap', gap: 8 }}>
-        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.15em', color: '#ff6b6b' }}>📚 Glossary</div>
+        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.15em', color: tabColor }}>📚 Glossary</div>
         <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
           <span style={{ fontSize: '0.77em', color: 'var(--mut)' }}>{filtered.length} term{filtered.length !== 1 ? 's' : ''}</span>
           <button onClick={() => goTo('wiki')} style={{ fontSize: '0.77em', padding: '3px 10px', borderRadius: 8, background: 'none', border: '1px solid var(--brd)', color: 'var(--dim)', cursor: 'pointer' }}>→ Full Wiki</button>
@@ -77,16 +79,16 @@ export default function Glossary({ db, goTo, goToWiki, navSearch }) {
             📥 Auto-imported ({autoCount})
           </button>
         )}
-        <FilterPopup color="#ff6b6b" filters={[{ key: 'category', label: 'Category', options: availableCats.map(c => ({ value: c, label: c })) }]} values={filterValues} onChange={(key, vals) => setFilterValues(prev => ({ ...prev, [key]: vals }))} />
+        <FilterPopup color={tabColor} filters={[{ key: 'category', label: 'Category', options: availableCats.map(c => ({ value: c, label: c })) }]} values={filterValues} onChange={(key, vals) => setFilterValues(prev => ({ ...prev, [key]: vals }))} />
       </div>
 
-      <AlphabetJumpBar entries={filtered} getName={e => e.term || e.title} onJump={target => scrollAndFlashEntry(target.id)} color="#ff6b6b" />
+      <AlphabetJumpBar entries={filtered} getName={e => e.term || e.title} onJump={target => scrollAndFlashEntry(target.id)} color={tabColor} />
 
       {articles.length === 0 && (
         <div className="empty">
           <div className="empty-icon">📚</div>
           <p>No Wiki entries yet.</p>
-          <button className="btn btn-primary" style={{ background: '#ff6b6b', marginTop: 8 }} onClick={() => goTo('wiki')}>→ Go to Wiki</button>
+          <button className="btn btn-primary" style={{ background: tabColor, marginTop: 8 }} onClick={() => goTo('wiki')}>→ Go to Wiki</button>
         </div>
       )}
 
@@ -99,13 +101,13 @@ export default function Glossary({ db, goTo, goToWiki, navSearch }) {
 
       {letters.map(letter => (
         <div key={letter} style={{ marginBottom: 20 }}>
-          <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.54em', fontWeight: 700, color: '#ff6b6b', borderBottom: '1px solid rgba(201,102,255,.2)', paddingBottom: 4, marginBottom: 8, letterSpacing: '.1em' }}>{letter}</div>
+          <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.54em', fontWeight: 700, color: tabColor, borderBottom: `1px solid ${tabColor}33`, paddingBottom: 4, marginBottom: 8, letterSpacing: '.1em' }}>{letter}</div>
           {grouped[letter].map(entry => (
             <div key={entry.id} id={`gcomp-entry-${entry.id}`} style={{ display: 'flex', gap: 12, padding: '8px 0', borderBottom: '1px solid rgba(255,255,255,.04)', cursor: 'pointer' }} onClick={() => goToWiki ? goToWiki(entry) : goTo('wiki')}>
               <div style={{ flex: 1 }}>
                 <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
                   <span style={{ fontFamily: "'Cinzel',serif", fontSize: '1em', fontWeight: 700, color: 'var(--tx)' }}>{entry.title}</span>
-                  <span style={{ fontSize: '0.69em', color: '#ff6b6b', textTransform: 'uppercase', letterSpacing: '.06em', opacity: 0.7 }}>{entry.category}</span>
+                  <span style={{ fontSize: '0.69em', color: tabColor, textTransform: 'uppercase', letterSpacing: '.06em', opacity: 0.7 }}>{entry.category}</span>
                   {entry.auto_imported && <span style={{ fontSize: '0.69em', color: '#ffcc00' }}>📥</span>}
                 </div>
                 {entry.summary && <div style={{ fontSize: '0.92em', color: 'var(--dim)', marginTop: 3, lineHeight: 1.5 }}>{entry.summary}</div>}

--- a/src/tabs/Inventory.jsx
+++ b/src/tabs/Inventory.jsx
@@ -5,7 +5,7 @@ import EntryForm from '../components/common/EntryForm'
 import Lightbox from '../components/common/Lightbox'
 import ImagePicker from '../components/common/ImagePicker'
 import { uploadImage } from '../hooks/useImageUpload'
-import { highlight, uid, SL } from '../constants'
+import { highlight, TAB_RAINBOW, uid, SL } from '../constants'
 import { scrollAndFlashEntry } from '../components/common/entryNav'
 
 // ── Category config ───────────────────────────────────────────────
@@ -336,6 +336,7 @@ function EntryPopup({ entry, allEntries, chars, db, onClose, onEdit, onTransfer,
 // MAIN INVENTORY COMPONENT
 // ══════════════════════════════════════════════════════════════════
 export default function Inventory({ db }) {
+  const tabColor = TAB_RAINBOW.inventory
   // Merge legacy items + wardrobe + inventory into one list
   const rawInventory = db.db.inventory || []
   const rawItems = (db.db.items || []).map(e => ({ ...e, _source: 'items',
@@ -357,7 +358,10 @@ export default function Inventory({ db }) {
 
   // ── State ──
   const [search, setSearch] = useState('')
-  const [viewMode, setViewMode] = useState('bubble') // 'bubble' | 'list' | 'outfit'
+  const [topTab, setTopTab] = useState(() => {
+    try { return localStorage.getItem('inventory_topTab') || 'items' } catch { return 'items' }
+  })
+  const [viewMode, setViewMode] = useState('bubble') // 'bubble' | 'list'
   const [filterCat, setFilterCat] = useState('all')
   const [filterChar, setFilterChar] = useState('all')
   const [filterGroup, setFilterGroup] = useState('all')
@@ -378,6 +382,7 @@ export default function Inventory({ db }) {
   const [dragIdx, setDragIdx] = useState(null)
   const [dragOverIdx, setDragOverIdx] = useState(null)
   const [showColPicker, setShowColPicker] = useState(false)
+  const [significantOnly, setSignificantOnly] = useState(false)
 
   useEffect(() => {
     function onExpand(e) {
@@ -398,6 +403,11 @@ export default function Inventory({ db }) {
   function saveColumns(n) {
     setColumns(n)
     db.saveSetting?.('inv_columns', String(n))
+  }
+
+  function pickTopTab(v) {
+    setTopTab(v)
+    try { localStorage.setItem('inventory_topTab', v) } catch {}
   }
 
   async function handleImageUpload(entryId, file) {
@@ -478,8 +488,9 @@ export default function Inventory({ db }) {
       const ch = chars.find(c => c.id === holderId)
       return ch?.groups?.split(',').map(g => g.trim()).includes(filterGroup)
     })()
-    return ms && mc && mch && mchg
-  }), [allEntries, search, filterCat, filterChar, filterChars, filterGroup, chars])
+    const sig = !significantOnly || (e.significance && e.significance.trim())
+    return ms && mc && mch && mchg && sig
+  }), [allEntries, search, filterCat, filterChar, filterChars, filterGroup, chars, significantOnly])
 
   // ── Grouping for bubble view ──
   const grouped = useMemo(() => {
@@ -517,7 +528,17 @@ export default function Inventory({ db }) {
 
   return (
     <div>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+        {[['items', '📦 All Items'], ['outfits', '👗 Outfits']].map(([k, l]) => (
+          <button key={k} onClick={() => pickTopTab(k)}
+            style={{ padding: '6px 12px', borderRadius: 8, border: `1px solid ${topTab === k ? tabColor : 'var(--brd)'}`, background: topTab === k ? `${tabColor}22` : 'transparent', color: topTab === k ? tabColor : 'var(--dim)', fontSize: '0.85em', fontWeight: 700, cursor: 'pointer' }}>
+            {l}
+          </button>
+        ))}
+      </div>
       {/* ── Toolbar ── */}
+      {topTab === 'items' && (
+        <>
       <div className="tbar" style={{ flexWrap: 'wrap', gap: 6 }}>
         <input className="sx" style={{ minWidth: 120 }} placeholder="Search inventory…"
           value={search} onChange={e => setSearch(e.target.value)} />
@@ -550,15 +571,23 @@ export default function Inventory({ db }) {
 
         {/* View toggle */}
         <div style={{ display: 'flex', gap: 3 }}>
-          {[['bubble','🫧 Bubbles'],['list','☰ List'],['outfit','👗 Outfits']].map(([v,l]) => (
+          {[['bubble','Bubbles'],['list','List']].map(([v,l]) => (
             <button key={v} onClick={() => setViewMode(v)}
               style={{ fontSize: '0.77em', padding: '3px 10px', borderRadius: 8, cursor: 'pointer',
                 fontWeight: viewMode === v ? 700 : 400,
-                background: viewMode === v ? 'var(--ci)' : 'none',
+                background: viewMode === v ? tabColor : 'none',
                 color: viewMode === v ? '#000' : 'var(--dim)',
-                border: `2px solid ${viewMode === v ? 'var(--ci)' : 'var(--brd)'}` }}>{l}</button>
+                border: `2px solid ${viewMode === v ? tabColor : 'var(--brd)'}` }}>{l}</button>
           ))}
         </div>
+
+        <button onClick={() => setSignificantOnly(v => !v)}
+          style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12,
+            border: `1px solid ${significantOnly ? tabColor : 'var(--brd)'}`,
+            background: significantOnly ? `${tabColor}22` : 'none',
+            color: significantOnly ? tabColor : 'var(--dim)', cursor: 'pointer' }}>
+          Significant only
+        </button>
 
         {/* List sort (only in list mode) */}
         {viewMode === 'list' && (
@@ -583,16 +612,16 @@ export default function Inventory({ db }) {
               {[1,2,3,4,5,8].map(n => (
                 <button key={n} onClick={() => { saveColumns(n); setShowColPicker(false) }}
                   style={{ width: 30, height: 30, borderRadius: 6, fontSize: '0.92em', fontWeight: 700,
-                    background: columns === n ? 'var(--ci)' : 'var(--card)',
+                    background: columns === n ? tabColor : 'var(--card)',
                     color: columns === n ? '#000' : 'var(--tx)',
-                    border: `1px solid ${columns === n ? 'var(--ci)' : 'var(--brd)'}`,
+                    border: `1px solid ${columns === n ? tabColor : 'var(--brd)'}`,
                     cursor: 'pointer' }}>{n}</button>
               ))}
             </div>
           )}
         </div>
 
-        <button className="btn btn-primary btn-sm" style={{ background: 'var(--ci)', marginLeft: 'auto' }}
+        <button className="btn btn-primary btn-sm" style={{ background: tabColor, marginLeft: 'auto' }}
           onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add</button>
       </div>
 
@@ -681,7 +710,10 @@ export default function Inventory({ db }) {
       )}
 
       {/* ── Outfit Snapshot view ── */}
-      {viewMode === 'outfit' && (
+        </>
+      )}
+
+      {topTab === 'outfits' && (
         <OutfitSnapshot db={db} chars={chars} allEntries={allEntries} />
       )}
 
@@ -707,12 +739,12 @@ export default function Inventory({ db }) {
         }} />
 
       <Modal open={modalOpen} onClose={() => { setModalOpen(false); setEditing(null) }}
-        title={`${editing?.id ? 'Edit' : 'Add'} Inventory Entry`} color="var(--ci)">
+        title={`${editing?.id ? 'Edit' : 'Add'} Inventory Entry`} color={tabColor}>
         <EntryForm fields={INV_FIELDS} entry={editing || {}} onSave={handleSave}
-          onCancel={() => { setModalOpen(false); setEditing(null) }} color="var(--ci)" db={db} />
+          onCancel={() => { setModalOpen(false); setEditing(null) }} color={tabColor} db={db} />
       </Modal>
 
-      <Modal open={!!transferId} onClose={() => setTransferId(null)} title="Transfer Item" color="var(--ci)">
+      <Modal open={!!transferId} onClose={() => setTransferId(null)} title="Transfer Item" color={tabColor}>
         <div className="field"><label>Transfer To</label>
           <select value={txForm.to} onChange={e => setTxForm(p => ({ ...p, to: e.target.value }))}>
             <option value="">— Pick character —</option>
@@ -728,7 +760,7 @@ export default function Inventory({ db }) {
         </div>
         <div className="modal-actions">
           <button className="btn btn-outline" onClick={() => setTransferId(null)}>Cancel</button>
-          <button className="btn btn-primary" style={{ background: 'var(--ci)' }} onClick={doTransfer}>Transfer</button>
+          <button className="btn btn-primary" style={{ background: tabColor }} onClick={doTransfer}>Transfer</button>
         </div>
       </Modal>
 

--- a/src/tabs/Locations.jsx
+++ b/src/tabs/Locations.jsx
@@ -2,9 +2,11 @@ import { useEffect, useRef, useState } from 'react'
 import Modal from '../components/common/Modal'
 import EntryForm from '../components/common/EntryForm'
 import AlphabetJumpBar from '../components/common/AlphabetJumpBar'
+import { TAB_RAINBOW } from '../constants'
 import { scrollAndFlashEntry } from '../components/common/entryNav'
 
-const TAB_COLOR = '#ffb700'
+const tabColor = TAB_RAINBOW['locations'] || '#aaaaaa'
+const COLS_MAP = { XS: 5, S: 4, M: 3, L: 2, XL: 1 }
 
 const LOC_FIELDS = [
   { k: 'name', l: 'Name', t: 'text', r: true },
@@ -29,7 +31,7 @@ function LocNode({ loc, locations, expanded, onToggle, onEdit, onDelete, onAddCh
   return (
     <div style={{ marginBottom: 2 }}>
       <div id={`gcomp-entry-${loc.id}`} className="loc-node" onClick={() => onToggle(loc.id)}>
-        {kids.length > 0 ? <span style={{ fontSize: '0.69em', color: TAB_COLOR, transition: '.2s', display: 'inline-block', transform: isOpen ? 'rotate(90deg)' : 'none' }}>►</span> : <span style={{ width: 12 }} />}
+        {kids.length > 0 ? <span style={{ fontSize: '0.69em', color: tabColor, transition: '.2s', display: 'inline-block', transform: isOpen ? 'rotate(90deg)' : 'none' }}>►</span> : <span style={{ width: 12 }} />}
         <span style={{ fontSize: '0.92em', fontWeight: 600 }}>{loc.name}</span>
         {loc.status && <span className={`badge badge-${loc.status}`} style={{ marginLeft: 4 }}>{loc.status}</span>}
         {loc.auto_imported && <span style={{ marginLeft: 6, fontSize: '0.69em', color: '#ffcc00' }}>📥</span>}
@@ -40,8 +42,8 @@ function LocNode({ loc, locations, expanded, onToggle, onEdit, onDelete, onAddCh
           {loc.description && <div>{loc.description}</div>}
           {loc.notes && <div className="entry-notes">{loc.notes}</div>}
           <div className="entry-actions" style={{ marginTop: 4 }}>
-            <button className="btn btn-sm btn-outline" style={{ color: TAB_COLOR, borderColor: TAB_COLOR }} onClick={e => { e.stopPropagation(); onEdit(loc) }}>✎ Edit</button>
-            <button className="btn btn-sm btn-outline" style={{ color: TAB_COLOR, borderColor: TAB_COLOR }} onClick={e => { e.stopPropagation(); onAddChild(loc.id) }}>+ Child</button>
+            <button className="btn btn-sm btn-outline" style={{ color: tabColor, borderColor: tabColor }} onClick={e => { e.stopPropagation(); onEdit(loc) }}>✎ Edit</button>
+            <button className="btn btn-sm btn-outline" style={{ color: tabColor, borderColor: tabColor }} onClick={e => { e.stopPropagation(); onAddChild(loc.id) }}>+ Child</button>
             <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544' }} onClick={e => { e.stopPropagation(); onDelete(loc.id) }}>✕</button>
           </div>
         </div>
@@ -90,9 +92,9 @@ function FlatTable({ locations, onEdit, onDelete, onAddChild, navSearch }) {
       <table style={{ borderCollapse: 'collapse', tableLayout: 'fixed', minWidth: colWidths.reduce((a, b) => a + b, 0) }}>
         <colgroup>{colWidths.map((w, i) => <col key={i} style={{ width: w }} />)}</colgroup>
         <thead>
-          <tr style={{ background: 'var(--sf)', borderBottom: `2px solid ${TAB_COLOR}` }}>
+          <tr style={{ background: 'var(--sf)', borderBottom: `2px solid ${tabColor}` }}>
             {COLS.map((col, i) => (
-              <th key={col} style={{ padding: '6px 8px', textAlign: 'left', fontSize: '0.77em', fontWeight: 700, color: TAB_COLOR, textTransform: 'uppercase', letterSpacing: '.05em', position: 'relative', userSelect: 'none', width: colWidths[i] }}>
+              <th key={col} style={{ padding: '6px 8px', textAlign: 'left', fontSize: '0.77em', fontWeight: 700, color: tabColor, textTransform: 'uppercase', letterSpacing: '.05em', position: 'relative', userSelect: 'none', width: colWidths[i] }}>
                 {col}
                 {i < COLS.length - 1 && <div onMouseDown={e => onMouseDown(e, i)} style={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 6, cursor: 'col-resize', background: 'transparent', zIndex: 1 }} />}
               </th>
@@ -104,12 +106,12 @@ function FlatTable({ locations, onEdit, onDelete, onAddChild, navSearch }) {
           {visible.map((l, idx) => (
             <tr key={l.id} id={`gcomp-entry-${l.id}`} style={{ background: idx % 2 === 0 ? 'var(--card)' : 'transparent' }}>
               <td style={tdStyle(0)}><span style={{ fontWeight: 600 }}>{l.name}</span></td>
-              <td style={tdStyle(1)}><span style={{ color: TAB_COLOR, fontSize: '0.85em' }}>{l.loc_type || '—'}</span></td>
+              <td style={tdStyle(1)}><span style={{ color: tabColor, fontSize: '0.85em' }}>{l.loc_type || '—'}</span></td>
               <td style={{ ...tdStyle(2), color: 'var(--dim)' }}>{locPath(l.id, locations) || '—'}</td>
               <td style={{ ...tdStyle(3), color: 'var(--dim)' }}>{l.description || '—'}</td>
               <td style={{ ...tdStyle(4), whiteSpace: 'nowrap' }}>
-                <button className="btn btn-sm btn-outline" style={{ color: TAB_COLOR, borderColor: TAB_COLOR, marginRight: 3 }} onClick={() => onEdit(l)}>✎</button>
-                <button className="btn btn-sm btn-outline" style={{ color: TAB_COLOR, borderColor: TAB_COLOR, marginRight: 3 }} onClick={() => onAddChild(l.id)}>+</button>
+                <button className="btn btn-sm btn-outline" style={{ color: tabColor, borderColor: tabColor, marginRight: 3 }} onClick={() => onEdit(l)}>✎</button>
+                <button className="btn btn-sm btn-outline" style={{ color: tabColor, borderColor: tabColor, marginRight: 3 }} onClick={() => onAddChild(l.id)}>+</button>
                 <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544' }} onClick={() => onDelete(l.id)}>✕</button>
               </td>
             </tr>
@@ -128,6 +130,13 @@ export default function Locations({ db, navSearch }) {
   const [editing, setEditing] = useState(null)
   const [confirmId, setConfirmId] = useState(null)
   const [autoOnly, setAutoOnly] = useState(false)
+  const [cols, setCols] = useState(() => {
+    try { return localStorage.getItem('locations_cols') || 'M' } catch { return 'M' }
+  })
+  function setColsPersist(v) {
+    setCols(v)
+    try { localStorage.setItem('locations_cols', v) } catch {}
+  }
 
   const search = (navSearch || '').toLowerCase()
   const autoCount = locations.filter(l => l.auto_imported === true).length
@@ -159,35 +168,46 @@ export default function Locations({ db, navSearch }) {
   const roots = locations.filter(l => !l.parent_id)
   const filtered = (search ? locations.filter(l => l.name?.toLowerCase().includes(search) || l.loc_type?.toLowerCase().includes(search)) : roots).filter(l => !autoOnly || l.auto_imported === true)
 
-  const btnStyle = active => ({ fontSize: '0.77em', padding: '3px 10px', borderRadius: 6, cursor: 'pointer', border: `1px solid ${active ? TAB_COLOR : 'var(--brd)'}`, background: active ? `${TAB_COLOR}22` : 'none', color: active ? TAB_COLOR : 'var(--dim)' })
+  const btnStyle = active => ({ fontSize: '0.77em', padding: '3px 10px', borderRadius: 6, cursor: 'pointer', border: `1px solid ${active ? tabColor : 'var(--brd)'}`, background: active ? `${tabColor}22` : 'none', color: active ? tabColor : 'var(--dim)' })
 
   return (
     <div>
       <div className="tbar">
-        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.15em', color: TAB_COLOR }}>🗺 Locations</div>
+        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.15em', color: tabColor }}>🗺 Locations</div>
         <div style={{ display: 'flex', gap: 4 }}>
           <button style={btnStyle(view === 'tree')} onClick={() => setView('tree')}>🌳 Tree</button>
           <button style={btnStyle(view === 'table')} onClick={() => setView('table')}>☰ Table</button>
         </div>
+        <div style={{ display: 'flex', gap: 4 }}>
+          {['XS','S','M','L','XL'].map(l => (
+            <button key={l} onClick={() => setColsPersist(l)}
+              style={{ fontSize: '0.77em', padding: '2px 7px',
+                borderRadius: 4, border: `1px solid ${cols === l ? tabColor : 'var(--brd)'}`,
+                background: cols === l ? `${tabColor}22` : 'transparent',
+                color: cols === l ? tabColor : 'var(--dim)', cursor: 'pointer' }}>
+              {l}
+            </button>
+          ))}
+        </div>
         {autoCount > 0 && <button onClick={() => setAutoOnly(v => !v)} style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: `1px solid ${autoOnly ? '#ffcc00' : 'var(--brd)'}`, background: autoOnly ? '#ffcc0022' : 'none', color: autoOnly ? '#ffcc00' : 'var(--dim)', cursor: 'pointer' }}>📥 Auto-imported ({autoCount})</button>}
-        <button className="btn btn-primary btn-sm" style={{ background: TAB_COLOR, color: '#000' }} onClick={() => openAdd()}>+ Add</button>
+        <button className="btn btn-primary btn-sm" style={{ background: tabColor, color: '#000' }} onClick={() => openAdd()}>+ Add</button>
       </div>
 
-      <AlphabetJumpBar entries={locations.filter(l => !autoOnly || l.auto_imported === true)} getName={e => e.name} onJump={target => scrollAndFlashEntry(target.id)} color={TAB_COLOR} />
+      <AlphabetJumpBar entries={locations.filter(l => !autoOnly || l.auto_imported === true)} getName={e => e.name} onJump={target => scrollAndFlashEntry(target.id)} color={tabColor} />
 
       {!locations.length && <div className="empty"><div className="empty-icon">🗺</div><p>No locations yet.</p></div>}
 
       {view === 'tree' && (
-        <>
+        <div style={{ display: 'grid', gridTemplateColumns: `repeat(${COLS_MAP[cols]}, 1fr)`, gap: 8, alignItems: 'start' }}>
           {filtered.map(l => <LocNode key={l.id} loc={l} locations={locations} expanded={expanded} onToggle={toggle} onEdit={e => { setEditing(e); setModalOpen(true) }} onDelete={id => setConfirmId(id)} onAddChild={openAdd} />)}
           {locations.filter(l => l.parent_id && !locations.find(p => p.id === l.parent_id)).map(l => <LocNode key={l.id} loc={l} locations={locations} expanded={expanded} onToggle={toggle} onEdit={e => { setEditing(e); setModalOpen(true) }} onDelete={id => setConfirmId(id)} onAddChild={openAdd} />)}
-        </>
+        </div>
       )}
 
       {view === 'table' && <FlatTable locations={locations.filter(l => !autoOnly || l.auto_imported === true)} navSearch={navSearch} onEdit={e => { setEditing(e); setModalOpen(true) }} onDelete={id => setConfirmId(id)} onAddChild={openAdd} />}
 
-      <Modal open={modalOpen} onClose={() => { setModalOpen(false); setEditing(null) }} title={`${editing?.id ? 'Edit' : 'Add'} Location`} color={TAB_COLOR}>
-        <EntryForm fields={LOC_FIELDS} entry={editing || {}} onSave={handleSave} onCancel={() => { setModalOpen(false); setEditing(null) }} color={TAB_COLOR} db={db} />
+      <Modal open={modalOpen} onClose={() => { setModalOpen(false); setEditing(null) }} title={`${editing?.id ? 'Edit' : 'Add'} Location`} color={tabColor}>
+        <EntryForm fields={LOC_FIELDS} entry={editing || {}} onSave={handleSave} onCancel={() => { setModalOpen(false); setEditing(null) }} color={tabColor} db={db} />
       </Modal>
 
       {confirmId && (

--- a/src/tabs/Manuscript.jsx
+++ b/src/tabs/Manuscript.jsx
@@ -470,6 +470,22 @@ export default function Manuscript({ db, navSearch, goTo }) {
                   <div style={{ marginTop: editCovers ? 4 : 8, textAlign: 'center', width: '100%' }}>
                     <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1em', color: accent, fontWeight: 700 }}>{book}</div>
                     <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginTop: 2 }}>{bookChapters.length} chapters · {words.toLocaleString()} words</div>
+                    {bookChapters.length > 0 && (
+                      <div style={{ display: 'flex', height: 6, borderRadius: 3, overflow: 'hidden', marginTop: 6, background: 'var(--brd)' }}>
+                        {STATUSES.map(s => {
+                          const n = bookChapters.filter(ch => ch.status === s).length
+                          if (!n) return null
+                          const pct = (n / bookChapters.length) * 100
+                          return (
+                            <div
+                              key={s}
+                              title={`${n} ${s}`}
+                              style={{ width: `${pct}%`, background: STATUS_COLORS[s] || 'var(--dim)' }}
+                            />
+                          )
+                        })}
+                      </div>
+                    )}
                     <div style={{ display: 'flex', gap: 2, marginTop: 4, flexWrap: 'wrap', justifyContent: 'center' }}>
                       {STATUSES.map(s => {
                         const n = bookChapters.filter(ch => ch.status === s).length
@@ -497,7 +513,6 @@ export default function Manuscript({ db, navSearch, goTo }) {
           </div>
         )}
         {!tocBook && <div style={{ marginRight: 'auto' }} />}
-        <input className="sx" placeholder="Search chapters and text..." value={search} onChange={e => setSearch(e.target.value)} style={{ flex: 1 }} />
         <select value={filterBook} onChange={e => setFilterBook(e.target.value)} style={{ fontSize: '0.77em', padding: '4px 8px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
           <option value="all">All books</option>
           {BOOKS.map(b => <option key={b} value={b}>{b}</option>)}

--- a/src/tabs/Manuscript.jsx
+++ b/src/tabs/Manuscript.jsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { uid } from '../constants'
+import { TAB_RAINBOW, uid } from '../constants'
 import { parseSetting } from '../hooks/useDB'
 
 const BOOKS = ['Book 1', 'Book 2', 'Book 3']
-const MS_COLOR = '#aacc00'
+const MS_COLOR = TAB_RAINBOW.manuscript
 const STATUSES = ['Draft', 'Revision', 'Polishing', 'Done']
 const STATUS_COLORS = { Draft: '#6b7280', Revision: '#f59e0b', Polishing: '#8b5cf6', Done: '#10b981' }
 const SHELF_COLS = { XS: 6, S: 4, M: 3, L: 2, XL: 1 }
@@ -14,18 +14,21 @@ const sizeBtn = active => ({ fontSize: '0.69em', padding: '2px 7px', borderRadiu
 function toHTML(text) {
   if (!text) return ''
   let t = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
-  t = t.replace(/^[ \t]*\*{3}[ \t]*$/gm, '\n<p style="text-align:center;letter-spacing:.3em">* * *</p>\n')
-  t = t.replace(/^[ \t]*---[ \t]*$/gm, '<hr>')
+  t = t.replace(/^[ \t]*\*{3}[ \t]*$/gm, '\n\n___SCENE_BREAK___\n\n')
+  t = t.replace(/^[ \t]*---[ \t]*$/gm, '\n\n___HR___\n\n')
   t = t.replace(/\*\*\*(.*?)\*\*\*/g, '<strong><em>$1</em></strong>')
   t = t.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
   t = t.replace(/\*(.*?)\*/g, '<em>$1</em>')
   t = t.replace(/_(.*?)_/g, '<em>$1</em>')
-  const paras = t.split(/\n{2,}/)
+  const hasBlankLines = /\n\s*\n/.test(t)
+  const paras = hasBlankLines ? t.split(/\n{2,}/) : t.split(/\n/)
   return paras.map(p => {
     const trimmed = p.trim()
     if (!trimmed) return ''
+    if (trimmed === '___SCENE_BREAK___') return '<p style="text-align:center;letter-spacing:.3em;margin:1.5em 0">* * *</p>'
+    if (trimmed === '___HR___') return '<hr>'
     if (trimmed.startsWith('<')) return trimmed
-    const flowed = trimmed.replace(/\n+/g, ' ').replace(/\s+/g, ' ')
+    const flowed = hasBlankLines ? trimmed.replace(/\n+/g, ' ').replace(/\s+/g, ' ') : trimmed
     return '<p>' + flowed + '</p>'
   }).filter(Boolean).join('\n')
 }
@@ -91,7 +94,9 @@ function FormatBar({ textareaRef, onUpdate }) {
   )
 }
 
-function ChapterEditor({ chapter, chars, allChapters, onSave, onClose, onNavigateToChapter, onBackToShelf, onBackToTOC }) {
+const navSelect = { fontSize: '0.85em', padding: '3px 8px', background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', maxWidth: 240 }
+
+function ChapterEditor({ chapter, chars, allChapters, onSave, onClose, onNavigateToChapter, onBackToShelf, onBackToTOC, onHome }) {
   const [text, setText] = useState(chapter.text || '')
   const [title, setTitle] = useState(chapter.title || '')
   const [status, setStatus] = useState(chapter.status || 'Draft')
@@ -135,7 +140,7 @@ function ChapterEditor({ chapter, chars, allChapters, onSave, onClose, onNavigat
 
   function changeFontSize(delta) {
     setFontSize(s => {
-      const next = Math.max(0.7, Math.min(1.8, s + delta))
+      const next = Math.max(0.9, Math.min(2.0, s + delta))
       try { localStorage.setItem('manuscript_fontsize', String(next)) } catch {}
       return next
     })
@@ -183,40 +188,44 @@ function ChapterEditor({ chapter, chars, allChapters, onSave, onClose, onNavigat
 
   return (
     <div style={{ position: 'fixed', inset: 0, zIndex: 400, background: 'var(--bg)', display: 'flex', flexDirection: 'column' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 14px', borderBottom: '1px solid var(--brd)', background: 'var(--card)', fontSize: '0.85em', flexWrap: 'wrap' }}>
-        <button onClick={onBackToShelf} style={navBtn}>← Shelf</button>
-        <button onClick={() => onBackToTOC(chapter.book)} style={navBtn}>← TOC</button>
-        <div style={{ width: 1, alignSelf: 'stretch', background: 'var(--brd)' }} />
-        <button onClick={navPrev} disabled={!prevChapter} style={{ ...navBtn, opacity: prevChapter ? 1 : 0.5, cursor: prevChapter ? 'pointer' : 'default' }}>← Prev Ch</button>
-        <button onClick={navNext} disabled={!nextChapter} style={{ ...navBtn, opacity: nextChapter ? 1 : 0.5, cursor: nextChapter ? 'pointer' : 'default' }}>Next Ch →</button>
-        <div style={{ width: 1, alignSelf: 'stretch', background: 'var(--brd)' }} />
-        <select value={chapter.id} onChange={e => onNavigateToChapter(e.target.value)} style={{ fontSize: '0.85em', padding: '3px 8px', background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', maxWidth: 240 }}>
-          {allChapters.map(c => (
-            <option key={c.id} value={c.id}>{c.book} · Ch {c.chapter_num} {c.title ? `· ${c.title}` : ''}</option>
-          ))}
-        </select>
-      </div>
-
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 14px', borderBottom: '1px solid var(--brd)', background: 'var(--sf)', flexWrap: 'wrap' }}>
-        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1em', color: MS_COLOR, flex: 1 }}>{chapter.book} · Ch. {chapter.chapter_num}</div>
         <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Chapter title..." style={{ flex: 2, minWidth: 200, fontSize: '1em', padding: '4px 8px', background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', fontFamily: "'Cinzel',serif" }} />
         <select value={status} onChange={e => setStatus(e.target.value)} style={{ fontSize: '0.85em', padding: '4px 8px', background: `${statusCol}22`, border: `1px solid ${statusCol}`, borderRadius: 6, color: statusCol, cursor: 'pointer' }}>
           {STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
         </select>
+        <span style={{ fontSize: '0.77em', color: 'var(--mut)', whiteSpace: 'nowrap' }}>{wc.toLocaleString()} words</span>
+        <button onClick={copyForSubstack} style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 6, background: MS_COLOR, color: '#fff', border: 'none', cursor: 'pointer', whiteSpace: 'nowrap' }}>{copied ? '✓ Copied!' : '📋 Copy for Substack'}</button>
+        <span style={{ fontSize: '0.77em', color: 'var(--mut)', whiteSpace: 'nowrap' }}>Notes ({annotations.length})</span>
+        <button onClick={save} style={{ fontSize: '0.85em', padding: '5px 14px', borderRadius: 6, background: MS_COLOR, color: '#000', border: 'none', cursor: 'pointer', fontWeight: 700 }}>Save</button>
+        <button onClick={onClose} style={{ background: 'none', border: 'none', color: 'var(--mut)', cursor: 'pointer', fontSize: '1.38em' }}>✕</button>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 14px', borderBottom: '1px solid var(--brd)', background: 'var(--sf)', flexWrap: 'wrap' }}>
+        <button onClick={() => changeFontSize(-0.1)} style={{ fontSize: '0.85em', padding: '3px 8px', borderRadius: 6, background: 'none', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }}>A−</button>
+        <button onClick={() => changeFontSize(0.1)} style={{ fontSize: '0.85em', padding: '3px 8px', borderRadius: 6, background: 'none', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }}>A+</button>
+        <span style={{ fontSize: '0.69em', color: 'var(--mut)' }}>{Math.round(fontSize * 100)}%</span>
+        <button onClick={toggleIndent} style={{ fontSize: '0.85em', padding: '3px 8px', borderRadius: 6, background: 'none', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }}>{indentParas ? '⇥ Indent: ON' : '⇥ Indent: OFF'}</button>
         <div style={{ display: 'flex', gap: 3 }}>
           {[['edit', '✎'], ['preview', '👁'], ['split', '⧉'], ['read', '📖']].map(([v, l]) => (
             <button key={v} onClick={() => setView(v)} title={v} style={{ fontSize: '0.85em', padding: '3px 8px', borderRadius: 6, background: view === v ? 'var(--csc)' : 'none', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }}>{l}</button>
           ))}
         </div>
-        <button onClick={() => changeFontSize(-0.1)} style={{ fontSize: '0.85em', padding: '3px 8px', borderRadius: 6, background: 'none', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }}>A−</button>
-        <button onClick={() => changeFontSize(0.1)} style={{ fontSize: '0.85em', padding: '3px 8px', borderRadius: 6, background: 'none', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }}>A+</button>
-        <span style={{ fontSize: '0.69em', color: 'var(--mut)' }}>{Math.round(fontSize * 100)}%</span>
-        <button onClick={toggleIndent} style={{ fontSize: '0.85em', padding: '3px 8px', borderRadius: 6, background: 'none', border: '1px solid var(--brd)', color: 'var(--tx)', cursor: 'pointer' }}>{indentParas ? '⇥ Indent: ON' : '⇥ Indent: OFF'}</button>
-        <span style={{ fontSize: '0.77em', color: 'var(--mut)', whiteSpace: 'nowrap' }}>{wc.toLocaleString()} words · ~{Math.round(wc / 250)} min read</span>
-        <button onClick={copyForSubstack} style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 6, background: MS_COLOR, color: '#fff', border: 'none', cursor: 'pointer', whiteSpace: 'nowrap' }}>{copied ? '✓ Copied!' : '📋 Copy for Substack'}</button>
         {view !== 'read' && <button onClick={() => setShowAnnotations(a => !a)} style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 6, background: showAnnotations ? 'var(--cca)' : 'none', color: showAnnotations ? '#000' : 'var(--dim)', border: '1px solid var(--brd)', cursor: 'pointer' }}>📝 Notes ({annotations.length})</button>}
-        <button onClick={save} style={{ fontSize: '0.85em', padding: '5px 14px', borderRadius: 6, background: MS_COLOR, color: '#000', border: 'none', cursor: 'pointer', fontWeight: 700 }}>Save</button>
-        <button onClick={onClose} style={{ background: 'none', border: 'none', color: 'var(--mut)', cursor: 'pointer', fontSize: '1.38em' }}>✕</button>
+      </div>
+
+      <div style={{ display: 'flex', gap: 6, alignItems: 'center', padding: '6px 14px', borderBottom: '1px solid var(--brd)', background: 'var(--card)', fontSize: '0.85em' }}>
+        <button onClick={onHome} title="Home" style={navBtn}>🏠</button>
+        <button onClick={onBackToShelf} title="Shelf" style={navBtn}>📚</button>
+        <button onClick={() => onBackToTOC(chapter.book)} title="Contents" style={navBtn}>📖</button>
+        <div style={{ width: 1, alignSelf: 'stretch', background: 'var(--brd)' }} />
+        <button onClick={navPrev} disabled={!prevChapter} title="Previous chapter" style={{ ...navBtn, opacity: prevChapter ? 1 : 0.5, cursor: prevChapter ? 'pointer' : 'default' }}>←</button>
+        <button onClick={navNext} disabled={!nextChapter} title="Next chapter" style={{ ...navBtn, opacity: nextChapter ? 1 : 0.5, cursor: nextChapter ? 'pointer' : 'default' }}>→</button>
+        <div style={{ width: 1, alignSelf: 'stretch', background: 'var(--brd)' }} />
+        <select value={chapter.id} onChange={e => onNavigateToChapter(e.target.value)} style={navSelect}>
+          {allChapters.map(c => (
+            <option key={c.id} value={c.id}>{c.book} · Ch {c.chapter_num}{c.title ? ` · ${c.title}` : ''}</option>
+          ))}
+        </select>
       </div>
 
       {detectedChars.length > 0 && (
@@ -284,7 +293,7 @@ function ChapterEditor({ chapter, chars, allChapters, onSave, onClose, onNavigat
   )
 }
 
-export default function Manuscript({ db, navSearch }) {
+export default function Manuscript({ db, navSearch, goTo }) {
   const chapters = (db.db.manuscript || []).sort((a, b) => {
     const bi = BOOKS.indexOf(a.book) - BOOKS.indexOf(b.book)
     if (bi !== 0) return bi
@@ -304,7 +313,7 @@ export default function Manuscript({ db, navSearch }) {
     try { return localStorage.getItem('manuscript_shelf_size') || 'M' } catch { return 'M' }
   })
   const [tocSize, setTocSize] = useState(() => {
-    try { return localStorage.getItem('manuscript_toc_size') || 'M' } catch { return 'M' }
+    try { return localStorage.getItem('manuscript_toc_size') || 'L' } catch { return 'L' }
   })
 
   useEffect(() => { setSearch(navSearch || '') }, [navSearch])
@@ -371,6 +380,12 @@ export default function Manuscript({ db, navSearch }) {
   function backToTOC(book) {
     setEditingChapter(null)
     setTocBook(book)
+  }
+
+  function goHome() {
+    setEditingChapter(null)
+    setTocBook(null)
+    goTo?.('dashboard')
   }
 
   function addChapter() {
@@ -528,6 +543,18 @@ export default function Manuscript({ db, navSearch }) {
             </div>
           )}
 
+          {tocSize === 'XL' ? (
+            <div style={{ maxWidth: '65ch', margin: '0 auto', padding: '20px 40px' }}>
+              {filtered.filter(ch => ch.book === tocBook).map(ch => (
+                <div key={ch.id} onClick={() => setEditingChapter(ch)}
+                  style={{ display: 'flex', alignItems: 'baseline', cursor: 'pointer', padding: '10px 0', borderBottom: '1px dotted var(--brd)', fontFamily: 'Georgia, serif' }}>
+                  <span style={{ fontSize: '1em', color: MS_COLOR, minWidth: 60 }}>Ch {ch.chapter_num}</span>
+                  <span style={{ flex: 1, fontSize: '1.08em' }}>{ch.title || '(Untitled)'}</span>
+                  <span style={{ fontSize: '0.85em', color: 'var(--mut)' }}>{ch.word_count || 0} words</span>
+                </div>
+              ))}
+            </div>
+          ) : (
           <div style={{ display: 'grid', gridTemplateColumns: `repeat(${TOC_COLS[tocSize]}, minmax(0, 1fr))`, gap: 8 }}>
             {filtered.filter(ch => ch.book === tocBook).map(ch => {
               const wc = ch.word_count || wordCount(ch.text || '')
@@ -541,6 +568,7 @@ export default function Manuscript({ db, navSearch }) {
               )
             })}
           </div>
+          )}
         </div>
       )}
 
@@ -561,7 +589,7 @@ export default function Manuscript({ db, navSearch }) {
       )}
 
       {editingChapter && (
-        <ChapterEditor chapter={editingChapter} chars={chars} allChapters={chapters} onSave={saveChapter} onClose={() => setEditingChapter(null)} onNavigateToChapter={navigateToChapter} onBackToShelf={backToShelf} onBackToTOC={backToTOC} />
+        <ChapterEditor chapter={editingChapter} chars={chars} allChapters={chapters} onSave={saveChapter} onClose={() => setEditingChapter(null)} onNavigateToChapter={navigateToChapter} onBackToShelf={backToShelf} onBackToTOC={backToTOC} onHome={() => goHome()} />
       )}
     </div>
   )

--- a/src/tabs/MapTab.jsx
+++ b/src/tabs/MapTab.jsx
@@ -1,8 +1,9 @@
 import { useState, useRef } from 'react'
 import Modal from '../components/common/Modal'
-import { uid } from '../constants'
+import { TAB_RAINBOW, uid } from '../constants'
 
 export default function MapTab({ db }) {
+  const tabColor = TAB_RAINBOW['map'] || '#aaaaaa'
   const maps = (db.db.maps || []).slice().sort((a, b) => {
     const ao = a.sort_order != null ? Number(a.sort_order) : 9999
     const bo = b.sort_order != null ? Number(b.sort_order) : 9999
@@ -105,9 +106,9 @@ export default function MapTab({ db }) {
           <button key={l} onClick={() => saveColCount(n)}
             style={{
               fontSize: 'var(--fs-xs)', padding: '2px 7px', borderRadius: 8,
-              background: colCount===n ? 'var(--cl)' : 'none',
+              background: colCount===n ? tabColor : 'none',
               color: colCount===n ? '#000' : 'var(--dim)',
-              border: `1px solid ${colCount===n ? 'var(--cl)' : 'var(--brd)'}`,
+              border: `1px solid ${colCount===n ? tabColor : 'var(--brd)'}`,
               cursor: 'pointer',
             }}>{l}</button>
         ))}
@@ -124,9 +125,9 @@ export default function MapTab({ db }) {
         {Object.entries(MAP_HEIGHTS).map(([l, h]) => (
           <button key={l} onClick={() => { setMapHeight(h); try { localStorage.setItem('map_img_height', String(h)) } catch {} }}
             style={{ fontSize: 'var(--fs-xs)', padding: '2px 7px', borderRadius: 8,
-              background: mapHeight === h ? 'var(--cl)' : 'none',
+              background: mapHeight === h ? tabColor : 'none',
               color: mapHeight === h ? '#000' : 'var(--dim)',
-              border: `1px solid ${mapHeight === h ? 'var(--cl)' : 'var(--brd)'}`,
+              border: `1px solid ${mapHeight === h ? tabColor : 'var(--brd)'}`,
               cursor: 'pointer' }}>{l}</button>
         ))}
         <span style={{ marginLeft: 'auto', fontSize: 'var(--fs-xs)', color: 'var(--mut)' }}>
@@ -135,15 +136,15 @@ export default function MapTab({ db }) {
       </div>
 
       <div className="tbar">
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.15em', color: 'var(--cl)' }}>🌍 Maps</div>
-        <button className="btn btn-primary btn-sm" style={{ background: 'var(--cl)', color: '#000' }} onClick={() => setAddingMap(true)}>+ Add Map</button>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.15em', color: tabColor }}>🌍 Maps</div>
+        <button className="btn btn-primary btn-sm" style={{ background: tabColor, color: '#000' }} onClick={() => setAddingMap(true)}>+ Add Map</button>
       </div>
 
       {!maps.length && (
         <div className="empty">
           <div className="empty-icon">🌍</div>
           <p>No maps yet. Upload your Lajen/Mnaerah maps here.</p>
-          <button className="btn btn-primary" style={{ background: 'var(--cl)', color: '#000' }} onClick={() => setAddingMap(true)}>+ Add Map</button>
+          <button className="btn btn-primary" style={{ background: tabColor, color: '#000' }} onClick={() => setAddingMap(true)}>+ Add Map</button>
         </div>
       )}
 
@@ -166,7 +167,7 @@ export default function MapTab({ db }) {
               transition: 'box-shadow .15s',
               cursor: 'grab',
             }}
-            onMouseEnter={e => e.currentTarget.style.boxShadow = '0 0 0 1px var(--cl)'}
+            onMouseEnter={e => e.currentTarget.style.boxShadow = `0 0 0 1px ${tabColor}`}
             onMouseLeave={e => e.currentTarget.style.boxShadow = 'none'}
           >
             {/* Drag handle bar */}
@@ -193,7 +194,7 @@ export default function MapTab({ db }) {
                 </div>
               )}
               <div style={{ marginTop: 6, display: 'flex', gap: 4 }}>
-                <button className="btn btn-sm btn-outline" style={{ color: 'var(--cl)', borderColor: 'var(--cl)' }} onClick={() => setLightboxSrc(m.src)}>🔍 Zoom</button>
+                <button className="btn btn-sm btn-outline" style={{ color: tabColor, borderColor: tabColor }} onClick={() => setLightboxSrc(m.src)}>🔍 Zoom</button>
                 <button className="btn btn-sm btn-outline" style={{ color: 'var(--dim)', borderColor: 'var(--brd)' }} onClick={() => setEditingMap({ id: m.id, name: m.name, notes: m.notes || '' })}>✎ Edit</button>
                 <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544' }} onClick={() => setConfirmId(m.id)}>✕</button>
               </div>
@@ -205,22 +206,22 @@ export default function MapTab({ db }) {
       {/* Locations reference */}
       {(db.db.locations||[]).length > 0 && (
         <div style={{ marginTop: 20 }}>
-          <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1em', color: 'var(--cl)', marginBottom: 8 }}>Locations for Reference</div>
+          <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1em', color: tabColor, marginBottom: 8 }}>Locations for Reference</div>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
             {(db.db.locations||[]).map(l => (
-              <span key={l.id} style={{ padding: '2px 8px', borderRadius: 10, fontSize: 'var(--fs-xs)', border: '1px solid rgba(0,229,204,.3)', color: 'var(--cl)', background: 'rgba(0,229,204,.05)' }}>{l.name}</span>
+              <span key={l.id} style={{ padding: '2px 8px', borderRadius: 10, fontSize: 'var(--fs-xs)', border: `1px solid ${tabColor}44`, color: tabColor, background: `${tabColor}11` }}>{l.name}</span>
             ))}
           </div>
         </div>
       )}
 
       {/* ── Add map modal ── */}
-      <Modal open={addingMap} onClose={() => setAddingMap(false)} title="Add Map" color="var(--cl)">
+      <Modal open={addingMap} onClose={() => setAddingMap(false)} title="Add Map" color={tabColor}>
         <div className="field"><label>Map Name</label><input value={newMapName} onChange={e => setNewMapName(e.target.value)} placeholder="e.g. Lajen World Map" /></div>
         <div className="field"><label>Notes</label><textarea value={newMapNotes} onChange={e => setNewMapNotes(e.target.value)} placeholder="Optional notes about this map…" /></div>
         <div className="field">
           <label>Image File(s)</label>
-          <label style={{ display: 'inline-block', padding: '8px 14px', background: 'var(--cl)', color: '#000', borderRadius: 'var(--r)', cursor: 'pointer', fontSize: '0.85em', fontWeight: 600 }}>
+          <label style={{ display: 'inline-block', padding: '8px 14px', background: tabColor, color: '#000', borderRadius: 'var(--r)', cursor: 'pointer', fontSize: '0.85em', fontWeight: 600 }}>
             📎 Choose Image(s)
             <input type="file" accept="image/*" multiple style={{ display: 'none' }} onChange={handleUpload} />
           </label>
@@ -231,14 +232,14 @@ export default function MapTab({ db }) {
       </Modal>
 
       {/* ── Edit map modal ── */}
-      <Modal open={!!editingMap} onClose={() => setEditingMap(null)} title="Edit Map" color="var(--cl)">
+      <Modal open={!!editingMap} onClose={() => setEditingMap(null)} title="Edit Map" color={tabColor}>
         {editingMap && (
           <>
             <div className="field"><label>Map Name</label><input value={editingMap.name} onChange={e => setEditingMap(p => ({ ...p, name: e.target.value }))} /></div>
             <div className="field"><label>Notes</label><textarea value={editingMap.notes} onChange={e => setEditingMap(p => ({ ...p, notes: e.target.value }))} placeholder="Optional notes…" /></div>
             <div className="modal-actions">
               <button className="btn btn-outline" onClick={() => setEditingMap(null)}>Cancel</button>
-              <button className="btn btn-primary" style={{ background: 'var(--cl)', color: '#000' }} onClick={saveEdit}>Save</button>
+              <button className="btn btn-primary" style={{ background: tabColor, color: '#000' }} onClick={saveEdit}>Save</button>
             </div>
           </>
         )}

--- a/src/tabs/MapTab.jsx
+++ b/src/tabs/MapTab.jsx
@@ -252,7 +252,7 @@ export default function MapTab({ db }) {
           onClick={() => setLightboxSrc(null)}
         >
           <img src={lightboxSrc} alt="Map" style={{ maxWidth: '100%', maxHeight: '90vh', objectFit: 'contain', borderRadius: 8 }} />
-          <button style={{ position: 'absolute', top: 16, right: 20, background: 'none', border: 'none', color: '#fff', fontSize: 24, cursor: 'pointer' }} onClick={() => setLightboxSrc(null)}>✕</button>
+          <button style={{ position: 'absolute', top: 16, right: 20, background: 'none', border: 'none', color: '#fff', fontSize: '1.85em', cursor: 'pointer' }} onClick={() => setLightboxSrc(null)}>✕</button>
         </div>
       )}
 

--- a/src/tabs/MapTab.jsx
+++ b/src/tabs/MapTab.jsx
@@ -135,7 +135,7 @@ export default function MapTab({ db }) {
       </div>
 
       <div className="tbar">
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: 15, color: 'var(--cl)' }}>🌍 Maps</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.15em', color: 'var(--cl)' }}>🌍 Maps</div>
         <button className="btn btn-primary btn-sm" style={{ background: 'var(--cl)', color: '#000' }} onClick={() => setAddingMap(true)}>+ Add Map</button>
       </div>
 
@@ -205,7 +205,7 @@ export default function MapTab({ db }) {
       {/* Locations reference */}
       {(db.db.locations||[]).length > 0 && (
         <div style={{ marginTop: 20 }}>
-          <div style={{ fontFamily: "'Cinzel', serif", fontSize: 13, color: 'var(--cl)', marginBottom: 8 }}>Locations for Reference</div>
+          <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1em', color: 'var(--cl)', marginBottom: 8 }}>Locations for Reference</div>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
             {(db.db.locations||[]).map(l => (
               <span key={l.id} style={{ padding: '2px 8px', borderRadius: 10, fontSize: 'var(--fs-xs)', border: '1px solid rgba(0,229,204,.3)', color: 'var(--cl)', background: 'rgba(0,229,204,.05)' }}>{l.name}</span>
@@ -220,7 +220,7 @@ export default function MapTab({ db }) {
         <div className="field"><label>Notes</label><textarea value={newMapNotes} onChange={e => setNewMapNotes(e.target.value)} placeholder="Optional notes about this map…" /></div>
         <div className="field">
           <label>Image File(s)</label>
-          <label style={{ display: 'inline-block', padding: '8px 14px', background: 'var(--cl)', color: '#000', borderRadius: 'var(--r)', cursor: 'pointer', fontSize: 11, fontWeight: 600 }}>
+          <label style={{ display: 'inline-block', padding: '8px 14px', background: 'var(--cl)', color: '#000', borderRadius: 'var(--r)', cursor: 'pointer', fontSize: '0.85em', fontWeight: 600 }}>
             📎 Choose Image(s)
             <input type="file" accept="image/*" multiple style={{ display: 'none' }} onChange={handleUpload} />
           </label>

--- a/src/tabs/Notes.jsx
+++ b/src/tabs/Notes.jsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react'
+import { TAB_RAINBOW } from '../constants'
 import StickiesView from './notes/StickiesView'
 import JournalView from './notes/JournalView'
+import IdeasView from './notes/IdeasView'
 
-const NOTES_COLOR = '#ffcc00'
+const NOTES_COLOR = TAB_RAINBOW.notes
 
 export default function Notes(props) {
   const { db } = props
@@ -25,6 +27,12 @@ export default function Notes(props) {
       if (sticky) {
         pick('stickies')
         setPendingExpandId(targetId)
+        return
+      }
+      const idea = (db.db.ideas_list || []).find(x => x.id === targetId)
+      if (idea) {
+        pick('ideas')
+        setPendingExpandId(targetId)
       }
     }
     window.addEventListener('gcomp_expand', onExpand)
@@ -39,7 +47,7 @@ export default function Notes(props) {
   return (
     <div>
       <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
-        {[['stickies', '📌 Stickies'], ['journal', '📝 Journal']].map(([k, l]) => (
+        {[['stickies', '📌 Stickies'], ['journal', '📝 Journal'], ['ideas', '💡 Ideas']].map(([k, l]) => (
           <button
             key={k}
             onClick={() => pick(k)}
@@ -49,7 +57,7 @@ export default function Notes(props) {
               border: `1px solid ${subTab === k ? NOTES_COLOR : 'var(--brd)'}`,
               background: subTab === k ? NOTES_COLOR : 'transparent',
               color: subTab === k ? '#000' : NOTES_COLOR,
-              fontSize: 11,
+              fontSize: '0.85em',
               fontWeight: 700,
               cursor: 'pointer',
             }}
@@ -59,8 +67,9 @@ export default function Notes(props) {
         ))}
       </div>
 
-      {subTab === 'stickies' && <StickiesView {...props} pendingExpandId={pendingExpandId} clearPendingExpandId={() => setPendingExpandId(null)} />}
+      {subTab === 'stickies' && <StickiesView {...props} goToSubTab={pick} pendingExpandId={pendingExpandId} clearPendingExpandId={() => setPendingExpandId(null)} />}
       {subTab === 'journal' && <JournalView {...props} pendingExpandId={pendingExpandId} clearPendingExpandId={() => setPendingExpandId(null)} />}
+      {subTab === 'ideas' && <IdeasView {...props} pendingExpandId={pendingExpandId} clearPendingExpandId={() => setPendingExpandId(null)} />}
     </div>
   )
 }

--- a/src/tabs/OutfitSnapshot.jsx
+++ b/src/tabs/OutfitSnapshot.jsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import { TAB_RAINBOW } from '../constants'
 
 const OUTFIT_SLOTS = [
   { id:'head',        label:'Head / Hat' },
@@ -21,14 +22,14 @@ const OUTFIT_SLOTS = [
   { id:'accessory_2', label:'Accessory 2' },
 ]
 
-function SlotPicker({ slot, charItems, value, onChange }) {
+function SlotPicker({ slot, charItems, value, onChange, tabColor }) {
   return (
     <div style={{ marginBottom: 6 }}>
       <div style={{ fontSize: '0.69em', fontWeight: 700, color: 'var(--mut)', textTransform: 'uppercase',
         letterSpacing: '.05em', marginBottom: 3 }}>{slot.label}</div>
       <select value={value || ''} onChange={e => onChange(slot.id, e.target.value)}
         style={{ width: '100%', fontSize: '0.77em', padding: '4px 8px', background: 'var(--sf)',
-          border: `1px solid ${value ? 'var(--ci)' : 'var(--brd)'}`, borderRadius: 6, color: 'var(--tx)' }}>
+          border: `1px solid ${value ? tabColor : 'var(--brd)'}`, borderRadius: 6, color: 'var(--tx)' }}>
         <option value="">— empty —</option>
         {charItems.map(item => (
           <option key={item.id} value={item.id}>{item.name}</option>
@@ -45,6 +46,7 @@ function SlotPicker({ slot, charItems, value, onChange }) {
 }
 
 export default function OutfitSnapshot({ db, chars, allEntries }) {
+  const tabColor = TAB_RAINBOW['items'] || '#aaaaaa'
   const [selectedChar, setSelectedChar] = useState('')
   const [slots, setSlots] = useState({})
   const [snapshotName, setSnapshotName] = useState('')
@@ -102,11 +104,11 @@ export default function OutfitSnapshot({ db, chars, allEntries }) {
   return (
     <div>
       <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 14, flexWrap: 'wrap' }}>
-        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.08em', color: 'var(--ci)' }}>👗 Outfit Snapshot</div>
+        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.08em', color: tabColor }}>👗 Outfit Snapshot</div>
         <button onClick={() => setShowSaved(s => !s)}
           style={{ fontSize: '0.77em', padding: '3px 10px', borderRadius: 10,
-            background: showSaved ? 'var(--ci)' : 'none', color: showSaved ? '#000' : 'var(--dim)',
-            border: '1px solid var(--ci)', cursor: 'pointer' }}>
+            background: showSaved ? tabColor : 'none', color: showSaved ? '#000' : 'var(--dim)',
+            border: `1px solid ${tabColor}`, cursor: 'pointer' }}>
           📂 Saved ({savedSnapshots.length})
         </button>
       </div>
@@ -118,7 +120,7 @@ export default function OutfitSnapshot({ db, chars, allEntries }) {
           {savedSnapshots.length === 0 && <div style={{ fontSize: '0.85em', color: 'var(--mut)' }}>No snapshots saved yet.</div>}
           {savedSnapshots.map(snap => (
             <div key={snap.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-              padding: '5px 8px', borderLeft: '3px solid var(--ci)', marginBottom: 4, background: 'var(--sf)', borderRadius: '0 6px 6px 0' }}>
+              padding: '5px 8px', borderLeft: `3px solid ${tabColor}`, marginBottom: 4, background: 'var(--sf)', borderRadius: '0 6px 6px 0' }}>
               <div>
                 <div style={{ fontSize: '0.85em', fontWeight: 600 }}>{snap.name}</div>
                 <div style={{ fontSize: '0.69em', color: 'var(--mut)' }}>{snap.characterName}{snap.scene ? ` · ${snap.scene}` : ''}</div>
@@ -126,7 +128,7 @@ export default function OutfitSnapshot({ db, chars, allEntries }) {
               <div style={{ display: 'flex', gap: 6 }}>
                 <button onClick={() => loadSnapshot(snap)}
                   style={{ fontSize: '0.69em', padding: '2px 8px', borderRadius: 6, background: 'none',
-                    border: '1px solid var(--ci)', color: 'var(--ci)', cursor: 'pointer' }}>Load</button>
+                    border: `1px solid ${tabColor}`, color: tabColor, cursor: 'pointer' }}>Load</button>
                 <button onClick={() => deleteSnapshot(snap.id)}
                   style={{ fontSize: '0.69em', padding: '2px 8px', borderRadius: 6, background: 'none',
                     border: '1px solid #ff335544', color: '#ff3355', cursor: 'pointer' }}>✕</button>
@@ -151,7 +153,7 @@ export default function OutfitSnapshot({ db, chars, allEntries }) {
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 8, marginBottom: 14 }}>
             {OUTFIT_SLOTS.map(slot => (
               <SlotPicker key={slot.id} slot={slot} charItems={charItems}
-                value={slots[slot.id] || ''} onChange={setSlot} />
+                value={slots[slot.id] || ''} onChange={setSlot} tabColor={tabColor} />
             ))}
           </div>
 
@@ -176,7 +178,7 @@ export default function OutfitSnapshot({ db, chars, allEntries }) {
               <input value={linkedScene} onChange={e => setLinkedScene(e.target.value)}
                 placeholder="e.g. Ch. 1 — Barn power manifestation" />
             </div>
-            <button className="btn btn-primary btn-sm" style={{ background: 'var(--ci)', alignSelf: 'flex-end' }}
+            <button className="btn btn-primary btn-sm" style={{ background: tabColor, alignSelf: 'flex-end' }}
               onClick={saveSnapshot} disabled={!snapshotName.trim()}>
               💾 Save Snapshot
             </button>

--- a/src/tabs/OutfitSnapshot.jsx
+++ b/src/tabs/OutfitSnapshot.jsx
@@ -24,10 +24,10 @@ const OUTFIT_SLOTS = [
 function SlotPicker({ slot, charItems, value, onChange }) {
   return (
     <div style={{ marginBottom: 6 }}>
-      <div style={{ fontSize: 9, fontWeight: 700, color: 'var(--mut)', textTransform: 'uppercase',
+      <div style={{ fontSize: '0.69em', fontWeight: 700, color: 'var(--mut)', textTransform: 'uppercase',
         letterSpacing: '.05em', marginBottom: 3 }}>{slot.label}</div>
       <select value={value || ''} onChange={e => onChange(slot.id, e.target.value)}
-        style={{ width: '100%', fontSize: 10, padding: '4px 8px', background: 'var(--sf)',
+        style={{ width: '100%', fontSize: '0.77em', padding: '4px 8px', background: 'var(--sf)',
           border: `1px solid ${value ? 'var(--ci)' : 'var(--brd)'}`, borderRadius: 6, color: 'var(--tx)' }}>
         <option value="">— empty —</option>
         {charItems.map(item => (
@@ -37,7 +37,7 @@ function SlotPicker({ slot, charItems, value, onChange }) {
       {value && (() => {
         const item = charItems.find(i => i.id === value)
         return item?.color_material ? (
-          <div style={{ fontSize: 9, color: 'var(--mut)', marginTop: 2, paddingLeft: 4 }}>{item.color_material}</div>
+          <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 2, paddingLeft: 4 }}>{item.color_material}</div>
         ) : null
       })()}
     </div>
@@ -102,9 +102,9 @@ export default function OutfitSnapshot({ db, chars, allEntries }) {
   return (
     <div>
       <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 14, flexWrap: 'wrap' }}>
-        <div style={{ fontFamily: "'Cinzel',serif", fontSize: 14, color: 'var(--ci)' }}>👗 Outfit Snapshot</div>
+        <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.08em', color: 'var(--ci)' }}>👗 Outfit Snapshot</div>
         <button onClick={() => setShowSaved(s => !s)}
-          style={{ fontSize: 10, padding: '3px 10px', borderRadius: 10,
+          style={{ fontSize: '0.77em', padding: '3px 10px', borderRadius: 10,
             background: showSaved ? 'var(--ci)' : 'none', color: showSaved ? '#000' : 'var(--dim)',
             border: '1px solid var(--ci)', cursor: 'pointer' }}>
           📂 Saved ({savedSnapshots.length})
@@ -114,21 +114,21 @@ export default function OutfitSnapshot({ db, chars, allEntries }) {
       {showSaved && (
         <div style={{ marginBottom: 14, padding: '10px 14px', background: 'var(--card)',
           border: '1px solid var(--brd)', borderRadius: 8 }}>
-          <div style={{ fontSize: 10, color: 'var(--mut)', marginBottom: 8 }}>All saved outfit snapshots</div>
-          {savedSnapshots.length === 0 && <div style={{ fontSize: 11, color: 'var(--mut)' }}>No snapshots saved yet.</div>}
+          <div style={{ fontSize: '0.77em', color: 'var(--mut)', marginBottom: 8 }}>All saved outfit snapshots</div>
+          {savedSnapshots.length === 0 && <div style={{ fontSize: '0.85em', color: 'var(--mut)' }}>No snapshots saved yet.</div>}
           {savedSnapshots.map(snap => (
             <div key={snap.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center',
               padding: '5px 8px', borderLeft: '3px solid var(--ci)', marginBottom: 4, background: 'var(--sf)', borderRadius: '0 6px 6px 0' }}>
               <div>
-                <div style={{ fontSize: 11, fontWeight: 600 }}>{snap.name}</div>
-                <div style={{ fontSize: 9, color: 'var(--mut)' }}>{snap.characterName}{snap.scene ? ` · ${snap.scene}` : ''}</div>
+                <div style={{ fontSize: '0.85em', fontWeight: 600 }}>{snap.name}</div>
+                <div style={{ fontSize: '0.69em', color: 'var(--mut)' }}>{snap.characterName}{snap.scene ? ` · ${snap.scene}` : ''}</div>
               </div>
               <div style={{ display: 'flex', gap: 6 }}>
                 <button onClick={() => loadSnapshot(snap)}
-                  style={{ fontSize: 9, padding: '2px 8px', borderRadius: 6, background: 'none',
+                  style={{ fontSize: '0.69em', padding: '2px 8px', borderRadius: 6, background: 'none',
                     border: '1px solid var(--ci)', color: 'var(--ci)', cursor: 'pointer' }}>Load</button>
                 <button onClick={() => deleteSnapshot(snap.id)}
-                  style={{ fontSize: 9, padding: '2px 8px', borderRadius: 6, background: 'none',
+                  style={{ fontSize: '0.69em', padding: '2px 8px', borderRadius: 6, background: 'none',
                     border: '1px solid #ff335544', color: '#ff3355', cursor: 'pointer' }}>✕</button>
               </div>
             </div>
@@ -160,7 +160,7 @@ export default function OutfitSnapshot({ db, chars, allEntries }) {
             <label>Additional notes (underwear, base layer, etc.)</label>
             <textarea value={slots._notes || ''} onChange={e => setSlot('_notes', e.target.value)} rows={2}
               placeholder="e.g. off-white linen shift underneath, hair braided..."
-              style={{ width: '100%', fontSize: 11, padding: '6px 8px', background: 'var(--sf)',
+              style={{ width: '100%', fontSize: '0.85em', padding: '6px 8px', background: 'var(--sf)',
                 border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', resize: 'vertical', boxSizing: 'border-box' }} />
           </div>
 

--- a/src/tabs/Questions.jsx
+++ b/src/tabs/Questions.jsx
@@ -1,4 +1,5 @@
 import GenericListTab from '../components/common/GenericListTab'
+import { TAB_RAINBOW } from '../constants'
 
 const Q_FIELDS = [
   { k: 'name', l: 'Question', t: 'text', r: true },
@@ -12,12 +13,14 @@ export default function Questions({ db, navSearch }) {
   return (
     <GenericListTab
       catKey="questions"
-      color="#c77dff"
+      color={TAB_RAINBOW.questions}
       icon="❓"
       label="Open Questions"
       fields={Q_FIELDS}
       db={db}
       navSearch={navSearch}
+      entityKey="questions"
+      tabColor={TAB_RAINBOW.questions}
     />
   )
 }

--- a/src/tabs/Scenes.jsx
+++ b/src/tabs/Scenes.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
 import Modal from '../components/common/Modal'
 import EntryForm from '../components/common/EntryForm'
-import { uid, RAINBOW, lerpColor, BKS } from '../constants'
+import { TAB_RAINBOW, uid, RAINBOW, lerpColor, BKS } from '../constants'
 import { scrollAndFlashEntry } from '../components/common/entryNav'
 
-const SC_COLOR = '#38b000'
+const SC_COLOR = TAB_RAINBOW['scenes'] || '#aaaaaa'
 const SCENE_FIELDS = [
   { k: 'name',              l: 'Scene',             t: 'text', r: true },
   { k: 'book',              l: 'Book',              t: 'sel', o: ['','Book 1','Book 2','Book 3'] },

--- a/src/tabs/SessionLog.jsx
+++ b/src/tabs/SessionLog.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { uid } from '../constants'
+import { TAB_RAINBOW, uid } from '../constants'
 import { supabase, hasSupabase } from '../supabase'
 
 // ── Rainbow spectrum for session cards ─────────────────────────
@@ -151,19 +151,19 @@ function SessionCard({ session, index, onEdit, onDelete, selected, onSelect }) {
         <input type="checkbox" checked={selected} onClick={e => e.stopPropagation()}
           onChange={e => onSelect(e.target.checked)} style={{ flexShrink: 0 }} />
         <div style={{ flex: 1 }}>
-          <div style={{ fontFamily: "'Cinzel',serif", fontSize: 13, fontWeight: 700, color: col }}>
+          <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1em', fontWeight: 700, color: col }}>
             Session {session.session_number} · {session.date}
           </div>
           {session.topics && (
-            <div style={{ fontSize: 11, color: 'var(--dim)', marginTop: 2 }}>{session.topics}</div>
+            <div style={{ fontSize: '0.85em', color: 'var(--dim)', marginTop: 2 }}>{session.topics}</div>
           )}
         </div>
         <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
           <button onClick={e => { e.stopPropagation(); onEdit(session) }}
-            style={{ fontSize: 11, padding: '2px 8px', borderRadius: 4, border: `1px solid ${col}66`, background: 'none', color: col, cursor: 'pointer' }}>Edit</button>
+            style={{ fontSize: '0.85em', padding: '2px 8px', borderRadius: 4, border: `1px solid ${col}66`, background: 'none', color: col, cursor: 'pointer' }}>Edit</button>
           <button onClick={e => { e.stopPropagation(); onDelete(session.id) }}
-            style={{ fontSize: 11, padding: '2px 8px', borderRadius: 4, border: '1px solid #cc444466', background: 'none', color: '#cc4444', cursor: 'pointer' }}>✕</button>
-          <span style={{ color: 'var(--dim)', fontSize: 14 }}>{expanded ? '▲' : '▼'}</span>
+            style={{ fontSize: '0.85em', padding: '2px 8px', borderRadius: 4, border: '1px solid #cc444466', background: 'none', color: '#cc4444', cursor: 'pointer' }}>✕</button>
+          <span style={{ color: 'var(--dim)', fontSize: '1.08em' }}>{expanded ? '▲' : '▼'}</span>
         </div>
       </div>
 
@@ -173,8 +173,8 @@ function SessionCard({ session, index, onEdit, onDelete, selected, onSelect }) {
             if (!session[k]?.trim()) return null
             return (
               <div key={k} style={{ marginTop: 10 }}>
-                <div style={{ fontSize: 10, fontWeight: 700, color: col, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 4 }}>{l}</div>
-                <div style={{ fontSize: 12, color: 'var(--tx)', whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>{session[k]}</div>
+                <div style={{ fontSize: '0.77em', fontWeight: 700, color: col, textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 4 }}>{l}</div>
+                <div style={{ fontSize: '0.92em', color: 'var(--tx)', whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>{session[k]}</div>
               </div>
             )
           })}
@@ -191,46 +191,46 @@ function SessionForm({ initial, onSave, onCancel }) {
   const inputStyle = {
     width: '100%', padding: '6px 9px', borderRadius: 6,
     border: '1px solid var(--brd)', background: 'var(--sf)',
-    color: 'var(--tx)', fontSize: 12, outline: 'none', boxSizing: 'border-box',
+    color: 'var(--tx)', fontSize: '0.92em', outline: 'none', boxSizing: 'border-box',
   }
   const taStyle = { ...inputStyle, minHeight: 80, resize: 'vertical', fontFamily: 'inherit' }
 
   return (
     <div style={{ background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 12, padding: 16, marginBottom: 14 }}>
-      <div style={{ fontFamily: "'Cinzel',serif", fontSize: 13, color: 'var(--cc)', marginBottom: 12, fontWeight: 700 }}>
+      <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1em', color: 'var(--cc)', marginBottom: 12, fontWeight: 700 }}>
         {initial.session_number ? `Edit Session ${initial.session_number}` : 'New Session'}
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 8, marginBottom: 10 }}>
         <div>
-          <div style={{ fontSize: 10, color: 'var(--dim)', marginBottom: 3, textTransform: 'uppercase' }}>Session #</div>
+          <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginBottom: 3, textTransform: 'uppercase' }}>Session #</div>
           <input type="number" value={form.session_number} onChange={e => set('session_number', e.target.value)} style={inputStyle} />
         </div>
         <div>
-          <div style={{ fontSize: 10, color: 'var(--dim)', marginBottom: 3, textTransform: 'uppercase' }}>Date</div>
+          <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginBottom: 3, textTransform: 'uppercase' }}>Date</div>
           <input type="date" value={form.date} onChange={e => set('date', e.target.value)} style={inputStyle} />
         </div>
         <div>
-          <div style={{ fontSize: 10, color: 'var(--dim)', marginBottom: 3, textTransform: 'uppercase' }}>Opened</div>
+          <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginBottom: 3, textTransform: 'uppercase' }}>Opened</div>
           <input value={form.opened_at} onChange={e => set('opened_at', e.target.value)} placeholder="e.g. 9:43 AM CDT" style={inputStyle} />
         </div>
         <div>
-          <div style={{ fontSize: 10, color: 'var(--dim)', marginBottom: 3, textTransform: 'uppercase' }}>Closed</div>
+          <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginBottom: 3, textTransform: 'uppercase' }}>Closed</div>
           <input value={form.closed_at} onChange={e => set('closed_at', e.target.value)} placeholder="e.g. 11:30 PM CDT" style={inputStyle} />
         </div>
       </div>
       <div style={{ marginBottom: 10 }}>
-        <div style={{ fontSize: 10, color: 'var(--dim)', marginBottom: 3, textTransform: 'uppercase' }}>Topics</div>
+        <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginBottom: 3, textTransform: 'uppercase' }}>Topics</div>
         <input value={form.topics} onChange={e => set('topics', e.target.value)} placeholder="Brief summary…" style={inputStyle} />
       </div>
       {SECTION_LABELS.map(({ k, l }) => (
         <div key={k} style={{ marginBottom: 8 }}>
-          <div style={{ fontSize: 10, color: 'var(--dim)', marginBottom: 3, textTransform: 'uppercase' }}>{l}</div>
+          <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginBottom: 3, textTransform: 'uppercase' }}>{l}</div>
           <textarea value={form[k]} onChange={e => set(k, e.target.value)} placeholder={`${l}…`} style={taStyle} />
         </div>
       ))}
       <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 12 }}>
-        <button onClick={onCancel} style={{ padding: '6px 16px', borderRadius: 6, border: '1px solid var(--brd)', background: 'none', color: 'var(--dim)', cursor: 'pointer', fontSize: 12 }}>Cancel</button>
-        <button onClick={() => onSave(form)} style={{ padding: '6px 16px', borderRadius: 6, border: 'none', background: 'var(--cc)', color: '#000', cursor: 'pointer', fontSize: 12, fontWeight: 700 }}>Save Session</button>
+        <button onClick={onCancel} style={{ padding: '6px 16px', borderRadius: 6, border: '1px solid var(--brd)', background: 'none', color: 'var(--dim)', cursor: 'pointer', fontSize: '0.92em' }}>Cancel</button>
+        <button onClick={() => onSave(form)} style={{ padding: '6px 16px', borderRadius: 6, border: 'none', background: 'var(--cc)', color: '#000', cursor: 'pointer', fontSize: '0.92em', fontWeight: 700 }}>Save Session</button>
       </div>
     </div>
   )
@@ -249,14 +249,14 @@ const ACTION_LABELS = {
   import: '⬆ Imported', restore: '⟲ Restored',
 }
 
-function ActivityLog({ activityLog, undoActivityRecord }) {
+function ActivityLog({ activityLog, undoActivityRecord, crossLink }) {
   const [filterAction, setFilterAction] = useState('all')
   const [filterCat, setFilterCat] = useState('all')
   const [search, setSearch] = useState('')
   const [expandedDiff, setExpandedDiff] = useState(null)
 
   const allActions = ['all', 'add', 'edit', 'delete', 'import', 'restore']
-  const allCats = ['all', ...new Set((activityLog || []).map(r => r.category).filter(Boolean))]
+  const allCats = ['all', ...new Set((activityLog || []).map(r => r.table || r.category).filter(Boolean))]
   const formatRecordTimestamp = (timestamp) => {
     if (!timestamp) return '—'
     const date = new Date(timestamp)
@@ -273,14 +273,21 @@ function ActivityLog({ activityLog, undoActivityRecord }) {
 
   const filtered = (activityLog || []).filter(r => {
     if (filterAction !== 'all' && r.action !== filterAction) return false
-    if (filterCat !== 'all' && r.category !== filterCat) return false
+    const cat = r.table || r.category
+    if (filterCat !== 'all' && cat !== filterCat) return false
     if (search) {
       const q = search.toLowerCase()
       if (!(r.entry_name || '').toLowerCase().includes(q) &&
-          !(r.category || '').toLowerCase().includes(q)) return false
+          !(cat || '').toLowerCase().includes(q)) return false
     }
     return true
   })
+
+  function onRowClick(record) {
+    if (record.recordId && record.table) {
+      crossLink?.(record.table, record.recordId)
+    }
+  }
 
   if (!activityLog || activityLog.length === 0) {
     return (
@@ -319,35 +326,38 @@ function ActivityLog({ activityLog, undoActivityRecord }) {
       </div>
 
       {filtered.map(record => {
-        const col = ACTION_COLORS[record.action] || 'var(--dim)'
+        const destCat = record.table || record.category || 'sessionlog'
+        const rowColor = TAB_RAINBOW[destCat] || TAB_RAINBOW.sessionlog
+        const actionIconColor = ACTION_COLORS[record.action] || 'var(--dim)'
         const isExpanded = expandedDiff === record.id
         return (
-          <div key={record.id} style={{
-            background: 'var(--card)', border: `1px solid ${col}33`,
-            borderLeft: `3px solid ${col}`, borderRadius: 8,
+          <div key={record.id} onClick={() => onRowClick(record)} style={{
+            background: 'var(--card)', border: `1px solid ${rowColor}33`,
+            borderLeft: `3px solid ${rowColor}`, borderRadius: 8,
             marginBottom: 6, padding: '8px 12px',
             opacity: record.undone ? 0.5 : 1,
+            cursor: record.recordId && record.table ? 'pointer' : 'default',
           }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <span style={{ fontSize: '0.85em', fontWeight: 700, color: col, minWidth: 80 }}>
+              <span style={{ fontSize: '0.77em', padding: '1px 6px', borderRadius: 4, border: `1px solid ${actionIconColor}66`, color: actionIconColor, marginRight: 8, fontWeight: 700, minWidth: 80, textAlign: 'center' }}>
                 {ACTION_LABELS[record.action] || record.action}
               </span>
               <span style={{ fontSize: '1em', color: 'var(--tx)', flex: 1 }}>
-                <span style={{ color: 'var(--dim)', fontSize: '0.8em' }}>{record.category} · </span>
+                <span style={{ color: rowColor, fontSize: '0.8em' }}>{destCat} · </span>
                 {record.entry_name}
               </span>
               <span style={{ fontSize: '0.8em', color: 'var(--mut)', whiteSpace: 'nowrap' }}>
                 {formatRecordTimestamp(record.timestamp)}
               </span>
               {record.diff && record.diff.length > 0 && (
-                <button onClick={() => setExpandedDiff(isExpanded ? null : record.id)}
+                <button onClick={e => { e.stopPropagation(); setExpandedDiff(isExpanded ? null : record.id) }}
                   style={{ fontSize: '0.8em', padding: '1px 6px', borderRadius: 4, border: '1px solid var(--brd)', background: 'none', color: 'var(--dim)', cursor: 'pointer' }}>
                   {isExpanded ? 'Hide diff' : `${record.diff.length} change${record.diff.length !== 1 ? 's' : ''}`}
                 </button>
               )}
               {!record.undone && (record.action === 'delete' || record.action === 'edit' || record.action === 'add') && (
-                <button onClick={() => undoActivityRecord(record.id)}
-                  style={{ fontSize: '0.8em', padding: '2px 8px', borderRadius: 4, border: `1px solid ${col}55`, background: 'none', color: col, cursor: 'pointer', fontWeight: 700 }}>
+                <button onClick={e => { e.stopPropagation(); undoActivityRecord(record.id) }}
+                  style={{ fontSize: '0.8em', padding: '2px 8px', borderRadius: 4, border: `1px solid ${actionIconColor}55`, background: 'none', color: actionIconColor, cursor: 'pointer', fontWeight: 700 }}>
                   ⟲ Undo
                 </button>
               )}
@@ -383,7 +393,7 @@ function ActivityLog({ activityLog, undoActivityRecord }) {
 }
 
 // ── Main SessionLog tab ────────────────────────────────────────
-export default function SessionLog({ db, goTo }) {
+export default function SessionLog({ db, goTo, crossLink }) {
   const [sessions, setSessions] = useState([])
   const [featureRegistry, setFeatureRegistry] = useState([])
   const [loading, setLoading] = useState(true)
@@ -522,18 +532,18 @@ export default function SessionLog({ db, goTo }) {
   )
 
   // Tab color for SessionLog is the last in the rainbow
-  const tabColor = '#ff44cc'
+  const tabColor = TAB_RAINBOW.sessionlog || '#ff44cc'
 
   return (
     <div>
       {/* Header */}
-      <div style={{ fontFamily: "'Cinzel',serif", fontSize: 15, color: tabColor, marginBottom: 12 }}>
+      <div style={{ fontFamily: "'Cinzel',serif", fontSize: '1.15em', color: tabColor, marginBottom: 12 }}>
         📋 Logs
       </div>
 
       {/* Flash */}
       {msg && (
-        <div style={{ fontSize: 12, color: 'var(--sl)', marginBottom: 10, padding: '6px 12px', background: 'var(--card)', borderRadius: 6, border: '1px solid var(--brd)' }}>{msg}</div>
+        <div style={{ fontSize: '0.92em', color: 'var(--sl)', marginBottom: 10, padding: '6px 12px', background: 'var(--card)', borderRadius: 6, border: '1px solid var(--brd)' }}>{msg}</div>
       )}
 
       <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
@@ -545,7 +555,7 @@ export default function SessionLog({ db, goTo }) {
             border: `1px solid ${subTab === 'sessions' ? tabColor : 'var(--brd)'}`,
             background: subTab === 'sessions' ? tabColor : 'transparent',
             color: subTab === 'sessions' ? '#000' : tabColor,
-            fontSize: 11,
+            fontSize: '0.85em',
             fontWeight: 700,
             cursor: 'pointer',
           }}
@@ -560,7 +570,7 @@ export default function SessionLog({ db, goTo }) {
             border: `1px solid ${subTab === 'activityfeatures' ? tabColor : 'var(--brd)'}`,
             background: subTab === 'activityfeatures' ? tabColor : 'transparent',
             color: subTab === 'activityfeatures' ? '#000' : tabColor,
-            fontSize: 11,
+            fontSize: '0.85em',
             fontWeight: 700,
             cursor: 'pointer',
           }}
@@ -571,26 +581,25 @@ export default function SessionLog({ db, goTo }) {
 
       {subTab === 'sessions' ? (
         <div>
-          <div style={{ fontSize: 12, fontWeight: 700, color: tabColor, marginBottom: 10, fontFamily: "'Cinzel',serif" }}>📋 Sessions</div>
           {/* Toolbar */}
           <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 12, alignItems: 'center' }}>
             <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Search sessions…"
-              style={{ flex: 1, minWidth: 160, padding: '6px 10px', borderRadius: 6, border: '1px solid var(--brd)', background: 'var(--sf)', color: 'var(--tx)', fontSize: 12, outline: 'none' }} />
+              style={{ flex: 1, minWidth: 160, padding: '6px 10px', borderRadius: 6, border: '1px solid var(--brd)', background: 'var(--sf)', color: 'var(--tx)', fontSize: '0.92em', outline: 'none' }} />
             {selected.size > 0 && (
               <>
-                <button onClick={exportSelected} style={{ fontSize: 11, padding: '4px 12px', borderRadius: 8, border: `1px solid ${tabColor}`, background: 'none', color: tabColor, cursor: 'pointer' }}>
+                <button onClick={exportSelected} style={{ fontSize: '0.85em', padding: '4px 12px', borderRadius: 8, border: `1px solid ${tabColor}`, background: 'none', color: tabColor, cursor: 'pointer' }}>
                   ↓ Export {selected.size} selected
                 </button>
-                <button onClick={() => setSelected(new Set())} style={{ fontSize: 11, padding: '4px 10px', borderRadius: 8, border: '1px solid var(--brd)', background: 'none', color: 'var(--dim)', cursor: 'pointer' }}>Clear</button>
+                <button onClick={() => setSelected(new Set())} style={{ fontSize: '0.85em', padding: '4px 10px', borderRadius: 8, border: '1px solid var(--brd)', background: 'none', color: 'var(--dim)', cursor: 'pointer' }}>Clear</button>
               </>
             )}
             {filtered.length > 0 && (
               <button onClick={() => setSelected(new Set(filtered.map(s => s.id)))}
-                style={{ fontSize: 10, padding: '3px 9px', borderRadius: 12, border: '1px solid var(--brd)', background: 'none', color: 'var(--dim)', cursor: 'pointer' }}>Select all</button>
+                style={{ fontSize: '0.77em', padding: '3px 9px', borderRadius: 12, border: '1px solid var(--brd)', background: 'none', color: 'var(--dim)', cursor: 'pointer' }}>Select all</button>
             )}
-            <button onClick={exportAll} style={{ fontSize: 11, padding: '4px 12px', borderRadius: 8, border: '1px solid var(--brd)', background: 'none', color: 'var(--dim)', cursor: 'pointer' }}>↓ Export All</button>
+            <button onClick={exportAll} style={{ fontSize: '0.85em', padding: '4px 12px', borderRadius: 8, border: '1px solid var(--brd)', background: 'none', color: 'var(--dim)', cursor: 'pointer' }}>↓ Export All</button>
             <button onClick={() => { setAdding(true); setEditing(null) }}
-              style={{ fontSize: 11, padding: '4px 12px', borderRadius: 8, border: 'none', background: tabColor, color: '#000', cursor: 'pointer', fontWeight: 700 }}>
+              style={{ fontSize: '0.85em', padding: '4px 12px', borderRadius: 8, border: 'none', background: tabColor, color: '#000', cursor: 'pointer', fontWeight: 700 }}>
               + New Session
             </button>
           </div>
@@ -599,7 +608,7 @@ export default function SessionLog({ db, goTo }) {
           {editing && <SessionForm initial={editing} onSave={saveSession} onCancel={() => setEditing(null)} />}
 
           {filtered.length === 0 ? (
-            <div style={{ textAlign: 'center', padding: '40px 20px', color: 'var(--mut)', fontStyle: 'italic', fontSize: 13 }}>
+            <div style={{ textAlign: 'center', padding: '40px 20px', color: 'var(--mut)', fontStyle: 'italic', fontSize: '1em' }}>
               {sessions.length === 0 ? 'No sessions yet. Add your first one!' : 'No sessions match this search.'}
             </div>
           ) : (
@@ -613,17 +622,17 @@ export default function SessionLog({ db, goTo }) {
               />
             ))
           )}
-          <div style={{ fontSize: 11, color: 'var(--dim)', textAlign: 'center', marginTop: 12 }}>
+          <div style={{ fontSize: '0.85em', color: 'var(--dim)', textAlign: 'center', marginTop: 12 }}>
             {filtered.length} session{filtered.length !== 1 ? 's' : ''} · {hasSupabase ? 'Cloud sync on' : 'Local only'}
           </div>
         </div>
       ) : (
         <div style={{ display: 'flex', gap: 0, alignItems: 'flex-start' }}>
           <div style={{ flex: '0 0 50%', minWidth: 0, paddingRight: 14 }}>
-            <div style={{ fontSize: '1em', fontWeight: 700, color: tabColor, marginBottom: 10, fontFamily: "'Cinzel',serif" }}>📊 Activity Log</div>
             <ActivityLog
               activityLog={db?.activityLog || []}
               undoActivityRecord={db?.undoActivityRecord}
+              crossLink={crossLink}
             />
           </div>
 
@@ -631,7 +640,7 @@ export default function SessionLog({ db, goTo }) {
 
           <div style={{ flex: '0 0 50%', minWidth: 0, paddingLeft: 14, display: 'flex', flexDirection: 'column', minHeight: 540 }}>
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
-              <div style={{ fontSize: '1em', fontWeight: 700, color: tabColor, fontFamily: "'Cinzel',serif" }}>⚙ Features</div>
+              <div style={{ fontSize: '1em', fontWeight: 700, color: tabColor, fontFamily: "'Cinzel',serif" }}>âš™ Features</div>
               <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
                 <button
                   onClick={() => setAddingFeature(v => !v)}
@@ -690,8 +699,9 @@ export default function SessionLog({ db, goTo }) {
             <div style={{ overflowY: 'auto', paddingRight: 2 }}>
               {featureRegistry.map(entry => {
                 const archived = entry.status === 'archived'
+                const featureColor = TAB_RAINBOW[entry.tab] || tabColor
                 return (
-                  <div key={entry.id} style={{
+                  <div key={entry.id} onClick={() => goTo?.(entry.tab)} style={{
                     display: 'flex',
                     alignItems: 'center',
                     gap: 6,
@@ -700,9 +710,11 @@ export default function SessionLog({ db, goTo }) {
                     marginBottom: 4,
                     borderRadius: 6,
                     background: 'var(--card)',
-                    border: '1px solid var(--brd)',
+                    border: `1px solid ${featureColor}33`,
+                    borderLeft: `3px solid ${featureColor}`,
                     opacity: archived ? 0.55 : 1,
                     textDecoration: archived ? 'line-through' : 'none',
+                    cursor: 'pointer',
                   }}>
                     <span style={{ flex: 1, minWidth: 0 }}>
                       <span style={{ color: 'var(--tx)', whiteSpace: 'normal' }}>
@@ -722,14 +734,14 @@ export default function SessionLog({ db, goTo }) {
                       </span>
                     </span>
                     <button
-                      onClick={() => goTo?.(entry.tab)}
+                      onClick={e => { e.stopPropagation(); goTo?.(entry.tab) }}
                       title={`Go to ${entry.tab}`}
-                      style={{ fontSize: '0.85em', padding: '1px 5px', borderRadius: 4, border: `1px solid ${tabColor}55`, background: 'none', color: tabColor, cursor: 'pointer' }}
+                      style={{ fontSize: '0.85em', padding: '1px 5px', borderRadius: 4, border: `1px solid ${featureColor}55`, background: 'none', color: featureColor, cursor: 'pointer' }}
                     >
                       ↗
                     </button>
                     <button
-                      onClick={() => toggleFeatureArchive(entry.id)}
+                      onClick={e => { e.stopPropagation(); toggleFeatureArchive(entry.id) }}
                       title={archived ? 'Restore to active' : 'Archive feature'}
                       style={{ fontSize: '1em', padding: '1px 6px', borderRadius: 4, border: '1px solid var(--brd)', background: 'none', color: 'var(--dim)', cursor: 'pointer' }}
                     >
@@ -745,3 +757,6 @@ export default function SessionLog({ db, goTo }) {
     </div>
   )
 }
+
+
+

--- a/src/tabs/Spellings.jsx
+++ b/src/tabs/Spellings.jsx
@@ -1,4 +1,5 @@
 import GenericListTab from '../components/common/GenericListTab'
+import { TAB_RAINBOW } from '../constants'
 
 const SP_FIELDS = [
   { k: 'name', l: 'Term', t: 'text', r: true },
@@ -11,13 +12,15 @@ export default function Spellings({ db, navSearch }) {
   return (
     <GenericListTab
       catKey="spellings"
-      color="#ff69b4"
+      color={TAB_RAINBOW.spellings}
       icon="✎"
       label="Spellings"
       fields={SP_FIELDS}
       db={db}
       navSearch={navSearch}
       getJumpName={e => e.word || e.name}
+      entityKey="spellings"
+      tabColor={TAB_RAINBOW.spellings}
     />
   )
 }

--- a/src/tabs/Timeline.jsx
+++ b/src/tabs/Timeline.jsx
@@ -172,14 +172,14 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
         <div style={{ display:'flex', gap:3 }}>
           {[['XS',8],['S',5],['M',3],['L',2],['XL',1]].map(([l,n]) => (
             <button key={l} onClick={() => saveColCount(n)}
-              style={{ fontSize:9, padding:'2px 7px', borderRadius:8,
+              style={{ fontSize: '0.69em', padding:'2px 7px', borderRadius:8,
                 background: colCount===n ? 'var(--ct)' : 'none',
                 color: colCount===n ? '#000' : 'var(--dim)',
                 border: `1px solid ${colCount===n ? 'var(--ct)' : 'var(--brd)'}`,
                 cursor:'pointer' }}>{l}</button>
           ))}
           <button onClick={toggleDividers}
-            style={{ fontSize:9, padding:'2px 7px', borderRadius:8, marginLeft:8,
+            style={{ fontSize: '0.69em', padding:'2px 7px', borderRadius:8, marginLeft:8,
               background: dividers ? 'rgba(255,255,255,.08)' : 'none',
               color: dividers ? 'var(--tx)' : 'var(--mut)',
               border:'1px solid var(--brd)', cursor:'pointer' }}>
@@ -217,44 +217,44 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
         <>
           {/* Visual track independent filter */}
           <div style={{ display:'flex', gap:6, flexWrap:'wrap', marginBottom:6 }}>
-            <span style={{ fontSize:10, color:'var(--mut)', alignSelf:'center' }}>Track filter:</span>
+            <span style={{ fontSize: '0.77em', color:'var(--mut)', alignSelf:'center' }}>Track filter:</span>
             <button className={`fp ${visualFilter==='all'?'active':''}`}
-              style={{ fontSize:10 }} onClick={() => setVisualFilter('all')}>All</button>
+              style={{ fontSize: '0.77em' }} onClick={() => setVisualFilter('all')}>All</button>
             {eras.map(era => (
               <button key={era} className={`fp ${visualFilter===era?'active':''}`}
-                style={{ fontSize:10, background: visualFilter===era ? ERA_BANDS[era]||'' : '' }}
+                style={{ fontSize: '0.77em', background: visualFilter===era ? ERA_BANDS[era]||'' : '' }}
                 onClick={() => setVisualFilter(visualFilter===era?'all':era)}>{era}</button>
             ))}
           </div>
           <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:6, paddingLeft:4 }}>
-            <span style={{ fontSize:10, color:'var(--mut)' }}>Zoom:</span>
-            <button className="btn btn-sm btn-outline" style={{ fontSize:11, padding:'2px 8px' }}
+            <span style={{ fontSize: '0.77em', color:'var(--mut)' }}>Zoom:</span>
+            <button className="btn btn-sm btn-outline" style={{ fontSize: '0.85em', padding:'2px 8px' }}
               onClick={() => setZoom(z => Math.max(0.05, z * 0.75))}>−</button>
-            <span style={{ fontSize:10, color:'var(--dim)', minWidth:36, textAlign:'center' }}>
+            <span style={{ fontSize: '0.77em', color:'var(--dim)', minWidth:36, textAlign:'center' }}>
               {Math.round(zoom * 100)}%
             </span>
-            <button className="btn btn-sm btn-outline" style={{ fontSize:11, padding:'2px 8px' }}
+            <button className="btn btn-sm btn-outline" style={{ fontSize: '0.85em', padding:'2px 8px' }}
               onClick={() => setZoom(z => Math.min(12, z * 1.33))}>+</button>
-            <button className="btn btn-sm btn-outline" style={{ fontSize:10, padding:'2px 8px' }}
+            <button className="btn btn-sm btn-outline" style={{ fontSize: '0.77em', padding:'2px 8px' }}
               onClick={() => setZoom(1)}>Reset</button>
-            <span style={{ fontSize:9, color:'var(--mut)', marginLeft:4 }}>
+            <span style={{ fontSize: '0.69em', color:'var(--mut)', marginLeft:4 }}>
               scroll or pinch to zoom · drag to pan
             </span>
-            <span style={{ fontSize:9, color:'var(--dim)', marginLeft:8 }}>Range:</span>
+            <span style={{ fontSize: '0.69em', color:'var(--dim)', marginLeft:8 }}>Range:</span>
             <input type="number" value={rangeMin} onChange={e => setRangeMin(e.target.value)}
               placeholder="Min sort#" title="Min sort order (leave blank for all)"
-              style={{ width:70, fontSize:9, padding:'2px 5px', background:'var(--sf)',
+              style={{ width:70, fontSize: '0.69em', padding:'2px 5px', background:'var(--sf)',
                 border:'1px solid var(--brd)', borderRadius:4, color:'var(--tx)' }} />
-            <span style={{ fontSize:9, color:'var(--dim)' }}>–</span>
+            <span style={{ fontSize: '0.69em', color:'var(--dim)' }}>–</span>
             <input type="number" value={rangeMax} onChange={e => setRangeMax(e.target.value)}
               placeholder="Max sort#"
-              style={{ width:70, fontSize:9, padding:'2px 5px', background:'var(--sf)',
+              style={{ width:70, fontSize: '0.69em', padding:'2px 5px', background:'var(--sf)',
                 border:'1px solid var(--brd)', borderRadius:4, color:'var(--tx)' }} />
             {(rangeMin || rangeMax) && (
-              <button className="btn btn-sm btn-outline" style={{ fontSize:9, padding:'1px 6px' }}
+              <button className="btn btn-sm btn-outline" style={{ fontSize: '0.69em', padding:'1px 6px' }}
                 onClick={() => { setRangeMin(''); setRangeMax('') }}>Clear</button>
             )}
-            <button className="btn btn-sm btn-outline" style={{ fontSize:9, padding:'1px 6px', color:'var(--cca)', borderColor:'var(--cca)' }}
+            <button className="btn btn-sm btn-outline" style={{ fontSize: '0.69em', padding:'1px 6px', color:'var(--cca)', borderColor:'var(--cca)' }}
               onClick={() => setEraEditor(true)} title="Manage era markers">⧖ Eras</button>
           </div>
           <div
@@ -277,7 +277,7 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
                   top:0, height:'100%', background:`${col}12`,
                   borderLeft:`2px solid ${col}88`, borderRight:`2px dashed ${col}66`,
                   pointerEvents:'none', zIndex:0 }}>
-                  <div style={{ position:'absolute', top:4, left:4, fontSize:9,
+                  <div style={{ position:'absolute', top:4, left:4, fontSize: '0.69em',
                     color:col, fontWeight:700, whiteSpace:'nowrap', opacity:0.9 }}>
                     {marker.name}
                   </div>
@@ -294,7 +294,7 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
               const x2 = Math.max(...xs) + 20
               return (
                 <div key={era} style={{ position: 'absolute', left: x1, width: x2-x1, top: 20, height: 140, background: bg, borderRadius: 6, pointerEvents: 'none' }}>
-                  <div style={{ fontSize: 8, color: 'rgba(255,255,255,.25)', padding: '2px 4px', pointerEvents: 'none' }}>{era}</div>
+                  <div style={{ fontSize: '0.62em', color: 'rgba(255,255,255,.25)', padding: '2px 4px', pointerEvents: 'none' }}>{era}</div>
                 </div>
               )
             })}
@@ -310,8 +310,8 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
                 <div key={e.id}>
                   <div className="timeline-dot" style={{ left: x-6, background: col, outline: isSelected ? `2px solid #fff` : 'none', outlineOffset:2 }} onClick={() => setTrackPopup(tp => tp===e.id ? null : e.id)} title={e.name} />
                   <div className="timeline-label" style={{ left: Math.max(0, Math.min(w-170, x-80)), top: labelRow, borderTop: `2px solid ${col}`, background: isSelected ? `${col}22` : undefined, borderRadius: isSelected ? 4 : undefined }}>
-                    <div style={{ fontWeight: 700, fontSize: 10 }}>{e.name}</div>
-                    <div style={{ color: 'var(--dim)', fontSize: 9 }}>{[e.date_hc, e.date_mnaerah].filter(Boolean).join(' / ')}</div>
+                    <div style={{ fontWeight: 700, fontSize: '0.77em' }}>{e.name}</div>
+                    <div style={{ color: 'var(--dim)', fontSize: '0.69em' }}>{[e.date_hc, e.date_mnaerah].filter(Boolean).join(' / ')}</div>
                   </div>
                 </div>
               )
@@ -331,14 +331,14 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
             borderRadius: 8, position: 'relative' }}>
             <button onClick={() => setTrackPopup(null)}
               style={{ position:'absolute', top:8, right:10, background:'none',
-                border:'none', color:'var(--mut)', cursor:'pointer', fontSize:16 }}>✕</button>
-            <div style={{ fontFamily:"'Cinzel',serif", fontSize:13, color:'var(--ct)', marginBottom:4 }}>{ev.name}</div>
-            <div style={{ fontSize:10, color:'var(--cca)', marginBottom:6 }}>
+                border:'none', color:'var(--mut)', cursor:'pointer', fontSize: '1.23em' }}>✕</button>
+            <div style={{ fontFamily:"'Cinzel',serif", fontSize: '1em', color:'var(--ct)', marginBottom:4 }}>{ev.name}</div>
+            <div style={{ fontSize: '0.77em', color:'var(--cca)', marginBottom:6 }}>
               {[ev.date_hc, ev.date_mnaerah].filter(Boolean).join(' / ')}
               {ev.era && <span style={{ marginLeft:8, color:'var(--dim)' }}>{ev.era}</span>}
             </div>
-            {ev.detail && <div style={{ fontSize:11, color:'var(--dim)', lineHeight:1.6, marginBottom:8 }}>{ev.detail}</div>}
-            {ev.notes && <div style={{ fontSize:11, color:'var(--mut)', fontStyle:'italic' }}>{ev.notes}</div>}
+            {ev.detail && <div style={{ fontSize: '0.85em', color:'var(--dim)', lineHeight:1.6, marginBottom:8 }}>{ev.detail}</div>}
+            {ev.notes && <div style={{ fontSize: '0.85em', color:'var(--mut)', fontStyle:'italic' }}>{ev.notes}</div>}
             <div style={{ display:'flex', gap:8, marginTop:8 }}>
               <button className="btn btn-sm btn-outline" style={{ color:'var(--ct)', borderColor:'var(--ct)' }}
                 onClick={() => { setEditing(ev); setModalOpen(true); setTrackPopup(null) }}>✎ Edit</button>
@@ -352,13 +352,13 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
       {/* List controls */}
       <div style={{ display:'flex', gap:8, alignItems:'center', marginTop:12, marginBottom:4,
         flexWrap:'wrap' }}>
-        <span style={{ fontSize:10, color:'var(--mut)' }}>List sort:</span>
+        <span style={{ fontSize: '0.77em', color:'var(--mut)' }}>List sort:</span>
         <button className={`fp ${listSort==='order'?'active':''}`}
-          style={{ fontSize:10 }} onClick={() => setListSort('order')}>Story Order</button>
+          style={{ fontSize: '0.77em' }} onClick={() => setListSort('order')}>Story Order</button>
         <button className={`fp ${listSort==='alpha'?'active':''}`}
-          style={{ fontSize:10 }} onClick={() => setListSort('alpha')}>A → Z</button>
+          style={{ fontSize: '0.77em' }} onClick={() => setListSort('alpha')}>A → Z</button>
         <button className={`fp ${listSort==='era'?'active':''}`}
-          style={{ fontSize:10 }} onClick={() => setListSort('era')}>By Era</button>
+          style={{ fontSize: '0.77em' }} onClick={() => setListSort('era')}>By Era</button>
       </div>
 
       {/* List */}
@@ -374,7 +374,7 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
             <div key={e.id} id={`gcomp-entry-${e.id}`} className="entry-card" style={{ breakInside: 'avoid', marginBottom: 6, '--card-color': 'var(--ct)' }} onClick={() => setExpanded(isOpen?null:e.id)}>
               <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                 <div className="entry-title" dangerouslySetInnerHTML={{ __html: highlight(e.name||'', search) }} />
-                <div style={{ fontSize: 10, color: 'var(--ct)' }}>{[e.date_hc, e.date_mnaerah].filter(Boolean).join(' / ')}</div>
+                <div style={{ fontSize: '0.77em', color: 'var(--ct)' }}>{[e.date_hc, e.date_mnaerah].filter(Boolean).join(' / ')}</div>
               </div>
               <div className="entry-meta">
                 {e.era && <span className="badge" style={{ color: 'var(--cca)', borderColor: 'rgba(255,170,51,.3)' }}>{e.era}</span>}
@@ -405,27 +405,27 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
           <div style={{ background:'var(--sf)', border:'1px solid var(--cca)',
             borderRadius:12, padding:20, maxWidth:480, width:'100%', maxHeight:'80vh', overflowY:'auto' }}
             onClick={e => e.stopPropagation()}>
-            <div style={{ fontFamily:"'Cinzel',serif", fontSize:14, color:'var(--cca)', marginBottom:14 }}>⧖ Era Markers</div>
-            <div style={{ fontSize:10, color:'var(--dim)', marginBottom:10 }}>
+            <div style={{ fontFamily:"'Cinzel',serif", fontSize: '1.08em', color:'var(--cca)', marginBottom:14 }}>⧖ Era Markers</div>
+            <div style={{ fontSize: '0.77em', color:'var(--dim)', marginBottom:10 }}>
               Markers appear as bands on the visual track. Use sort# values to set start/end positions.
             </div>
             {eraMarkers.map((m, i) => (
               <div key={i} style={{ display:'flex', gap:6, alignItems:'center', marginBottom:6, padding:'6px 8px',
                 background:'var(--card)', borderRadius:6, borderLeft:`3px solid ${m.color||'#4488ff'}` }}>
                 <input value={m.name} onChange={e => { const n=[...eraMarkers]; n[i]={...n[i],name:e.target.value}; saveEraMarkers(n) }}
-                  style={{ flex:1, fontSize:11, padding:'3px 6px', background:'var(--sf)', border:'1px solid var(--brd)', borderRadius:4, color:'var(--tx)' }}
+                  style={{ flex:1, fontSize: '0.85em', padding:'3px 6px', background:'var(--sf)', border:'1px solid var(--brd)', borderRadius:4, color:'var(--tx)' }}
                   placeholder="Era name" />
                 <input type="number" value={m.start} onChange={e => { const n=[...eraMarkers]; n[i]={...n[i],start:e.target.value}; saveEraMarkers(n) }}
-                  style={{ width:60, fontSize:10, padding:'3px 5px', background:'var(--sf)', border:'1px solid var(--brd)', borderRadius:4, color:'var(--tx)' }}
+                  style={{ width:60, fontSize: '0.77em', padding:'3px 5px', background:'var(--sf)', border:'1px solid var(--brd)', borderRadius:4, color:'var(--tx)' }}
                   placeholder="Start#" />
-                <span style={{ fontSize:10, color:'var(--mut)' }}>–</span>
+                <span style={{ fontSize: '0.77em', color:'var(--mut)' }}>–</span>
                 <input type="number" value={m.end} onChange={e => { const n=[...eraMarkers]; n[i]={...n[i],end:e.target.value}; saveEraMarkers(n) }}
-                  style={{ width:60, fontSize:10, padding:'3px 5px', background:'var(--sf)', border:'1px solid var(--brd)', borderRadius:4, color:'var(--tx)' }}
+                  style={{ width:60, fontSize: '0.77em', padding:'3px 5px', background:'var(--sf)', border:'1px solid var(--brd)', borderRadius:4, color:'var(--tx)' }}
                   placeholder="End#" />
                 <input type="color" value={m.color||'#4488ff'} onChange={e => { const n=[...eraMarkers]; n[i]={...n[i],color:e.target.value}; saveEraMarkers(n) }}
                   style={{ width:28, height:26, border:'none', borderRadius:4, cursor:'pointer', background:'none' }} />
                 <button onClick={() => saveEraMarkers(eraMarkers.filter((_,j) => j!==i))}
-                  style={{ background:'none', border:'none', color:'#ff3355', cursor:'pointer', fontSize:14 }}>✕</button>
+                  style={{ background:'none', border:'none', color:'#ff3355', cursor:'pointer', fontSize: '1.08em' }}>✕</button>
               </div>
             ))}
             <button className="btn btn-sm btn-outline" style={{ marginTop:8, color:'var(--cca)', borderColor:'var(--cca)' }}

--- a/src/tabs/Timeline.jsx
+++ b/src/tabs/Timeline.jsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import Modal from '../components/common/Modal'
 import EntryForm from '../components/common/EntryForm'
-import { highlight, SL, uid } from '../constants'
+import { TAB_RAINBOW, highlight, SL, uid } from '../constants'
 import { scrollAndFlashEntry } from '../components/common/entryNav'
 
 const TL_FIELDS = [
@@ -25,6 +25,7 @@ const ERA_BANDS = {
 const DOT_COLS = ['var(--ct)','var(--cc)','var(--ccn)','var(--cl)','var(--ci)','var(--cw)','var(--cq)']
 
 export default function Timeline({ db, crossLink, clearCrossLink }) {
+  const tabColor = TAB_RAINBOW['timeline'] || '#aaaaaa'
   const events = db.db.timeline || []
   const [search, setSearch] = useState('')
   const [colCount, setColCount] = useState(() => parseInt(db.getSetting?.('tl_cols') || '2'))
@@ -173,9 +174,9 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
           {[['XS',8],['S',5],['M',3],['L',2],['XL',1]].map(([l,n]) => (
             <button key={l} onClick={() => saveColCount(n)}
               style={{ fontSize: '0.69em', padding:'2px 7px', borderRadius:8,
-                background: colCount===n ? 'var(--ct)' : 'none',
+                background: colCount===n ? tabColor : 'none',
                 color: colCount===n ? '#000' : 'var(--dim)',
-                border: `1px solid ${colCount===n ? 'var(--ct)' : 'var(--brd)'}`,
+                border: `1px solid ${colCount===n ? tabColor : 'var(--brd)'}`,
                 cursor:'pointer' }}>{l}</button>
           ))}
           <button onClick={toggleDividers}
@@ -189,7 +190,7 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
         <button className="btn btn-sm btn-outline" onClick={() => setShowVisual(v => !v)}>
           {showVisual ? 'Hide' : 'Show'} Track
         </button>
-        <button className="btn btn-primary btn-sm" style={{ background: 'var(--ct)' }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add</button>
+        <button className="btn btn-primary btn-sm" style={{ background: tabColor }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add</button>
       </div>
       </div>
 
@@ -327,12 +328,12 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
         if (!ev) return null
         return (
           <div style={{ margin: '6px 0 10px', padding: '10px 14px',
-            background: 'var(--card)', border: '1px solid var(--ct)',
+            background: 'var(--card)', border: `1px solid ${tabColor}`,
             borderRadius: 8, position: 'relative' }}>
             <button onClick={() => setTrackPopup(null)}
               style={{ position:'absolute', top:8, right:10, background:'none',
                 border:'none', color:'var(--mut)', cursor:'pointer', fontSize: '1.23em' }}>✕</button>
-            <div style={{ fontFamily:"'Cinzel',serif", fontSize: '1em', color:'var(--ct)', marginBottom:4 }}>{ev.name}</div>
+            <div style={{ fontFamily:"'Cinzel',serif", fontSize: '1em', color:tabColor, marginBottom:4 }}>{ev.name}</div>
             <div style={{ fontSize: '0.77em', color:'var(--cca)', marginBottom:6 }}>
               {[ev.date_hc, ev.date_mnaerah].filter(Boolean).join(' / ')}
               {ev.era && <span style={{ marginLeft:8, color:'var(--dim)' }}>{ev.era}</span>}
@@ -340,7 +341,7 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
             {ev.detail && <div style={{ fontSize: '0.85em', color:'var(--dim)', lineHeight:1.6, marginBottom:8 }}>{ev.detail}</div>}
             {ev.notes && <div style={{ fontSize: '0.85em', color:'var(--mut)', fontStyle:'italic' }}>{ev.notes}</div>}
             <div style={{ display:'flex', gap:8, marginTop:8 }}>
-              <button className="btn btn-sm btn-outline" style={{ color:'var(--ct)', borderColor:'var(--ct)' }}
+              <button className="btn btn-sm btn-outline" style={{ color:tabColor, borderColor:tabColor }}
                 onClick={() => { setEditing(ev); setModalOpen(true); setTrackPopup(null) }}>✎ Edit</button>
               <button className="btn btn-sm btn-outline" style={{ color:'#ff3355', borderColor:'#ff335544' }}
                 onClick={() => { setConfirmId(ev.id); setTrackPopup(null) }}>✕ Delete</button>
@@ -365,16 +366,16 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
       <div className="cg" style={{ marginTop: 4, columns: colCount, columnGap: 12, columnRule: '1px solid var(--brd)' }}>
         {!sorted.length && (
           <div className="empty"><div className="empty-icon">⏳</div><p>No events yet.</p>
-            <button className="btn btn-primary" style={{ background: 'var(--ct)' }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add Event</button>
+            <button className="btn btn-primary" style={{ background: tabColor }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ Add Event</button>
           </div>
         )}
         {sorted.map((e, i) => {
           const isOpen = colCount === 1 || expanded === e.id  // XL auto-expands all
           return (
-            <div key={e.id} id={`gcomp-entry-${e.id}`} className="entry-card" style={{ breakInside: 'avoid', marginBottom: 6, '--card-color': 'var(--ct)' }} onClick={() => setExpanded(isOpen?null:e.id)}>
+            <div key={e.id} id={`gcomp-entry-${e.id}`} className="entry-card" style={{ breakInside: 'avoid', marginBottom: 6, '--card-color': tabColor }} onClick={() => setExpanded(isOpen?null:e.id)}>
               <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                 <div className="entry-title" dangerouslySetInnerHTML={{ __html: highlight(e.name||'', search) }} />
-                <div style={{ fontSize: '0.77em', color: 'var(--ct)' }}>{[e.date_hc, e.date_mnaerah].filter(Boolean).join(' / ')}</div>
+                <div style={{ fontSize: '0.77em', color: tabColor }}>{[e.date_hc, e.date_mnaerah].filter(Boolean).join(' / ')}</div>
               </div>
               <div className="entry-meta">
                 {e.era && <span className="badge" style={{ color: 'var(--cca)', borderColor: 'rgba(255,170,51,.3)' }}>{e.era}</span>}
@@ -387,7 +388,7 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
                   </div>
                   {e.notes && <div className="entry-notes">{e.notes}</div>}
                   <div className="entry-actions">
-                    <button className="btn btn-sm btn-outline" style={{ color: 'var(--ct)', borderColor: 'var(--ct)' }} onClick={ev => { ev.stopPropagation(); setEditing(e); setModalOpen(true) }}>✎ Edit</button>
+                    <button className="btn btn-sm btn-outline" style={{ color: tabColor, borderColor: tabColor }} onClick={ev => { ev.stopPropagation(); setEditing(e); setModalOpen(true) }}>✎ Edit</button>
                     <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544' }} onClick={ev => { ev.stopPropagation(); setConfirmId(e.id) }}>✕</button>
                   </div>
                 </>
@@ -439,8 +440,8 @@ export default function Timeline({ db, crossLink, clearCrossLink }) {
         </div>
       )}
 
-      <Modal open={modalOpen} onClose={() => { setModalOpen(false); setEditing(null) }} title={`${editing?.id?'Edit':'Add'} Event`} color="var(--ct)">
-        <EntryForm fields={TL_FIELDS} entry={editing||{}} onSave={handleSave} onCancel={() => { setModalOpen(false); setEditing(null) }} color="var(--ct)" db={db} />
+      <Modal open={modalOpen} onClose={() => { setModalOpen(false); setEditing(null) }} title={`${editing?.id?'Edit':'Add'} Event`} color={tabColor}>
+        <EntryForm fields={TL_FIELDS} entry={editing||{}} onSave={handleSave} onCancel={() => { setModalOpen(false); setEditing(null) }} color={tabColor} db={db} />
       </Modal>
 
       {confirmId && (

--- a/src/tabs/Tools.jsx
+++ b/src/tabs/Tools.jsx
@@ -580,7 +580,7 @@ function PronunciationTool() {
                   )}
                 </div>
                 <div style={{ flex: 1 }}>
-                  <span style={{ fontSize: 17, fontFamily: "'Cinzel',serif",
+                  <span style={{ fontSize: '1.31em', fontFamily: "'Cinzel',serif",
                     color: 'var(--cwr)', fontWeight: 700 }}>{r.phonetic}</span>
                 </div>
                 <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>

--- a/src/tabs/Tools.jsx
+++ b/src/tabs/Tools.jsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
-import { RATIO, LDAYS, MDAYS, LDPM, MONTHS } from '../constants'
+import { RATIO, TAB_RAINBOW, LDAYS, MDAYS, LDPM, MONTHS } from '../constants'
 
 // ── Tool definitions for nav ─────────────────────────────────────
 const TOOLS = [
@@ -621,6 +621,7 @@ function PronunciationTool() {
 
 
 export default function Tools({ db }) {
+  const tabColor = TAB_RAINBOW['tools'] || '#aaaaaa'
   const [lYear, setLYear] = useState(320)
   const [lMonth, setLMonth] = useState(1)
   const [lDay, setLDay] = useState(1)
@@ -718,7 +719,7 @@ export default function Tools({ db }) {
   return (
     <div>
       {/* ── Title ── */}
-      <div style={{ fontFamily:"'Cinzel',serif", fontSize: '1.15em', color:'var(--ctl)', marginBottom:10 }}>🔧 Tools</div>
+      <div style={{ fontFamily:"'Cinzel',serif", fontSize: '1.15em', color:tabColor, marginBottom:10 }}>🔧 Tools</div>
 
       {/* ── Quick-nav bar ── */}
       <div style={{ display:'flex', flexWrap:'wrap', gap:6, marginBottom:16, padding:'8px 10px',

--- a/src/tabs/Tools.jsx
+++ b/src/tabs/Tools.jsx
@@ -316,7 +316,7 @@ function IxCitlatlTool() {
   return (
     <div className="tool-card" id="tool-ixcitlatl">
       <h3 style={{ color: 'var(--cl)' }}>✦ Ix'Citlatl Name Converter</h3>
-      <div style={{ fontSize: 10, color: 'var(--dim)', marginBottom: 10, lineHeight: 1.5 }}>
+      <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginBottom: 10, lineHeight: 1.5 }}>
         Converts any name into its Ix'Citlatl equivalent across all 12 Mesoamerican language systems.
         Female private names begin with <strong style={{ color: 'var(--cl)' }}>Ix</strong> (pronounced "eesh"),
         male with <strong style={{ color: 'var(--cca)' }}>Ah</strong>.
@@ -345,16 +345,16 @@ function IxCitlatlTool() {
         <div>
           {history.map(h => (
             <div key={h.id} style={{ marginBottom: 16 }}>
-              <div style={{ fontSize: 10, color: 'var(--cca)', fontWeight: 700, marginBottom: 6 }}>
+              <div style={{ fontSize: '0.77em', color: 'var(--cca)', fontWeight: 700, marginBottom: 6 }}>
                 {h.original} <span style={{ color: 'var(--dim)', fontWeight: 400 }}>({h.gender})</span>
               </div>
               <div style={{ overflowX: 'auto' }}>
-                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 10 }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.77em' }}>
                   <thead>
                     <tr>
-                      <th style={{ textAlign: 'left', color: 'var(--dim)', padding: '2px 8px 4px 0', fontSize: 9, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '.04em', whiteSpace: 'nowrap' }}>Language System</th>
-                      <th style={{ textAlign: 'left', color: 'var(--dim)', padding: '2px 8px 4px 0', fontSize: 9, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '.04em' }}>Result</th>
-                      <th style={{ textAlign: 'left', color: 'var(--dim)', padding: '2px 8px 4px 0', fontSize: 9, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '.04em' }}>Notes</th>
+                      <th style={{ textAlign: 'left', color: 'var(--dim)', padding: '2px 8px 4px 0', fontSize: '0.69em', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '.04em', whiteSpace: 'nowrap' }}>Language System</th>
+                      <th style={{ textAlign: 'left', color: 'var(--dim)', padding: '2px 8px 4px 0', fontSize: '0.69em', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '.04em' }}>Result</th>
+                      <th style={{ textAlign: 'left', color: 'var(--dim)', padding: '2px 8px 4px 0', fontSize: '0.69em', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '.04em' }}>Notes</th>
                       <th></th>
                     </tr>
                   </thead>
@@ -363,16 +363,16 @@ function IxCitlatlTool() {
                       <tr key={r.system} style={{ borderTop: '1px solid rgba(255,255,255,.04)', background: i % 2 === 0 ? 'transparent' : 'rgba(255,255,255,.02)' }}>
                         <td style={{ padding: '5px 8px 5px 0', color: 'var(--dim)', whiteSpace: 'nowrap' }}>{r.label}</td>
                         <td style={{ padding: '5px 8px 5px 0' }}>
-                          <span style={{ fontFamily: "'Cinzel',serif", fontSize: 13, fontWeight: 700,
+                          <span style={{ fontFamily: "'Cinzel',serif", fontSize: '1em', fontWeight: 700,
                             color: h.gender === 'female' ? 'var(--cl)' : 'var(--cca)' }}>
                             {r.result}
                           </span>
                         </td>
-                        <td style={{ padding: '5px 8px 5px 0', color: 'var(--mut)', fontSize: 9, fontStyle: 'italic' }}>{r.note}</td>
+                        <td style={{ padding: '5px 8px 5px 0', color: 'var(--mut)', fontSize: '0.69em', fontStyle: 'italic' }}>{r.note}</td>
                         <td style={{ padding: '5px 0', whiteSpace: 'nowrap' }}>
-                          <button style={{ background: 'none', border: 'none', color: 'var(--dim)', cursor: 'pointer', fontSize: 10, padding: '0 3px' }}
+                          <button style={{ background: 'none', border: 'none', color: 'var(--dim)', cursor: 'pointer', fontSize: '0.77em', padding: '0 3px' }}
                             onClick={() => navigator.clipboard?.writeText(r.result)} title="Copy">📋</button>
-                          <button style={{ background: 'none', border: 'none', color: 'var(--dim)', cursor: 'pointer', fontSize: 10, padding: '0 3px' }}
+                          <button style={{ background: 'none', border: 'none', color: 'var(--dim)', cursor: 'pointer', fontSize: '0.77em', padding: '0 3px' }}
                             onClick={() => speak(r.result)} title="Hear pronunciation">🔊</button>
                         </td>
                       </tr>
@@ -382,7 +382,7 @@ function IxCitlatlTool() {
               </div>
             </div>
           ))}
-          <button style={{ fontSize: 9, color: 'var(--mut)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+          <button style={{ fontSize: '0.69em', color: 'var(--mut)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
             onClick={() => saveHistory([])}>Clear history</button>
         </div>
       )}
@@ -518,7 +518,7 @@ function PronunciationTool() {
   return (
     <div className="tool-card" id="tool-pronun">
       <h3 style={{ color: 'var(--cwr)' }}>🔊 Pronunciation Helper</h3>
-      <div style={{ fontSize: 10, color: 'var(--dim)', marginBottom: 10, lineHeight: 1.5 }}>
+      <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginBottom: 10, lineHeight: 1.5 }}>
         Enter any word or name. Real-world language systems (Murvetian/Italian, Thaeronic/Greek, etc.)
         will attempt a translation first, then apply phonetic rules.
         In-world language systems apply phonetic rendering directly.
@@ -557,7 +557,7 @@ function PronunciationTool() {
       )}
 
       {!sys.confirmed && system !== 'manual' && system !== 'all' && (
-        <div style={{ fontSize: 10, color: 'var(--sp)', padding: '4px 8px', background: 'rgba(255,204,0,.07)',
+        <div style={{ fontSize: '0.77em', color: 'var(--sp)', padding: '4px 8px', background: 'rgba(255,204,0,.07)',
           borderRadius: 4, marginBottom: 8, border: '1px solid rgba(255,204,0,.2)' }}>
           ⚠ {sys.label} phonology not yet confirmed — output is approximate.
           {sys.realBase && <span> Translation via MyMemory API.</span>}
@@ -571,10 +571,10 @@ function PronunciationTool() {
               border: '1px solid var(--brd)', borderRadius: 'var(--r)', marginBottom: 6 }}>
               <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, flexWrap: 'wrap' }}>
                 <div style={{ minWidth: 110 }}>
-                  <div style={{ fontSize: 9, color: 'var(--mut)', textTransform: 'uppercase',
+                  <div style={{ fontSize: '0.69em', color: 'var(--mut)', textTransform: 'uppercase',
                     letterSpacing: '.05em', marginBottom: 2 }}>{r.system}</div>
                   {r.translated && (
-                    <div style={{ fontSize: 9, color: 'var(--dim)', fontStyle: 'italic' }}>
+                    <div style={{ fontSize: '0.69em', color: 'var(--dim)', fontStyle: 'italic' }}>
                       → {r.translated} (translated)
                     </div>
                   )}
@@ -584,15 +584,15 @@ function PronunciationTool() {
                     color: 'var(--cwr)', fontWeight: 700 }}>{r.phonetic}</span>
                 </div>
                 <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
-                  <button style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 15 }}
+                  <button style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '1.15em' }}
                     onClick={() => speak(r.phonetic)} title="Hear it">🔊</button>
                   <button style={{ background: 'none', border: '1px solid var(--brd)', color: 'var(--dim)',
-                    cursor: 'pointer', fontSize: 9, padding: '2px 6px', borderRadius: 3 }}
+                    cursor: 'pointer', fontSize: '0.69em', padding: '2px 6px', borderRadius: 3 }}
                     onClick={() => navigator.clipboard?.writeText(r.phonetic)}>Copy</button>
                 </div>
               </div>
               {!r.confirmed && (
-                <div style={{ fontSize: 9, color: 'var(--mut)', marginTop: 4 }}>
+                <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 4 }}>
                   ⚠ Unconfirmed phonology
                 </div>
               )}
@@ -603,10 +603,10 @@ function PronunciationTool() {
 
       {/* Ix'Citlatl reference guide */}
       <details style={{ marginTop: 10 }}>
-        <summary style={{ fontSize: 10, color: 'var(--dim)', cursor: 'pointer', userSelect: 'none' }}>
+        <summary style={{ fontSize: '0.77em', color: 'var(--dim)', cursor: 'pointer', userSelect: 'none' }}>
           📖 Ix'Citlatl Sound Guide
         </summary>
-        <div style={{ marginTop: 6, padding: 8, background: 'var(--card)', borderRadius: 'var(--r)', fontSize: 10, lineHeight: 1.8 }}>
+        <div style={{ marginTop: 6, padding: 8, background: 'var(--card)', borderRadius: 'var(--r)', fontSize: '0.77em', lineHeight: 1.8 }}>
           {[["Ix'","eesh (prefix)"],["x","sh (as in 'shell')"],["tl","tl as one sound (like in 'Nahuatl')"],["tz","ts (as in 'bits')"],["hu","w"],["'","glottal stop (like 'uh-oh')"],["c (before a/o)","k"],["c (before e/i)","s"],["ll","long L"]].map(([sym,val]) => (
             <div key={sym} style={{ display: 'flex', gap: 8 }}>
               <span style={{ color: 'var(--cl)', minWidth: 80, fontFamily: "'Cinzel',serif" }}>{sym}</span>
@@ -718,15 +718,15 @@ export default function Tools({ db }) {
   return (
     <div>
       {/* ── Title ── */}
-      <div style={{ fontFamily:"'Cinzel',serif", fontSize:15, color:'var(--ctl)', marginBottom:10 }}>🔧 Tools</div>
+      <div style={{ fontFamily:"'Cinzel',serif", fontSize: '1.15em', color:'var(--ctl)', marginBottom:10 }}>🔧 Tools</div>
 
       {/* ── Quick-nav bar ── */}
       <div style={{ display:'flex', flexWrap:'wrap', gap:6, marginBottom:16, padding:'8px 10px',
         background:'var(--card)', border:'1px solid var(--brd)', borderRadius:'var(--rl)' }}>
-        <span style={{ fontSize:9, color:'var(--dim)', alignSelf:'center', marginRight:4, textTransform:'uppercase', letterSpacing:'.04em' }}>Jump to:</span>
+        <span style={{ fontSize: '0.69em', color:'var(--dim)', alignSelf:'center', marginRight:4, textTransform:'uppercase', letterSpacing:'.04em' }}>Jump to:</span>
         {TOOLS.map(t => (
           <button key={t.id}
-            style={{ fontSize:10, padding:'3px 10px', borderRadius:12, background:'none',
+            style={{ fontSize: '0.77em', padding:'3px 10px', borderRadius:12, background:'none',
               border:`1px solid ${t.color}44`, color:t.color, cursor:'pointer', whiteSpace:'nowrap',
               transition:'.2s' }}
             onMouseDown={e => e.currentTarget.style.background = `${t.color}22`}
@@ -783,8 +783,8 @@ export default function Tools({ db }) {
         {/* ── Time Elapsed ── */}
         <div className="tool-card" id="tool-elapsed">
           <h3 style={{ color:'var(--cq)' }}>⏱ Time Elapsed</h3>
-          <div style={{ fontSize:10, color:'var(--dim)', marginBottom:8 }}>Pick events from the dropdown or enter years manually.</div>
-          <div style={{ fontSize:10, color:'var(--cca)', marginBottom:4, fontWeight:600 }}>START</div>
+          <div style={{ fontSize: '0.77em', color:'var(--dim)', marginBottom:8 }}>Pick events from the dropdown or enter years manually.</div>
+          <div style={{ fontSize: '0.77em', color:'var(--cca)', marginBottom:4, fontWeight:600 }}>START</div>
           <div className="field"><label>Pick event (optional)</label>
             <select value={eEv1} onChange={e => setEEv1(e.target.value)}>
               <option value="">— Manual entry —</option>
@@ -804,7 +804,7 @@ export default function Tools({ db }) {
               </div>
             </div>
           )}
-          <div style={{ fontSize:10, color:'var(--cca)', marginBottom:4, fontWeight:600, marginTop:8 }}>END</div>
+          <div style={{ fontSize: '0.77em', color:'var(--cca)', marginBottom:4, fontWeight:600, marginTop:8 }}>END</div>
           <div className="field"><label>Pick event (optional)</label>
             <select value={eEv2} onChange={e => setEEv2(e.target.value)}>
               <option value="">— Manual entry —</option>
@@ -865,7 +865,7 @@ export default function Tools({ db }) {
               <Row label="Equivalent Lajen time" value={`${ageResult.lAge.toFixed(1)} Lajen years`} />
             </div>
           ) : (
-            <div style={{ fontSize:10, color:'var(--mut)', marginTop:6 }}>Pick character + event, or enter years manually.</div>
+            <div style={{ fontSize: '0.77em', color:'var(--mut)', marginTop:6 }}>Pick character + event, or enter years manually.</div>
           )}
         </div>
 
@@ -899,7 +899,7 @@ export default function Tools({ db }) {
         {/* ── Birthday Backfill ── */}
         <div className="tool-card" id="tool-backfill">
           <h3 style={{ color:'var(--cfl)' }}>🗓 Backfill Birthday Timeline Entries</h3>
-          <div style={{ fontSize:10, color:'var(--dim)', marginBottom:10, lineHeight:1.5 }}>
+          <div style={{ fontSize: '0.77em', color:'var(--dim)', marginBottom:10, lineHeight:1.5 }}>
             Auto-creates a timeline entry for every character who has a Lajen birthday set,
             but doesn't yet have a matching "Birthday: [Name]" event in the timeline.
             Safe to run multiple times — won't create duplicates.
@@ -1000,7 +1000,7 @@ function ScotsDialogueTool() {
   return (
     <div className="tool-card" id="tool-scots">
       <h3 style={{ color: 'var(--cca)' }}>🏴󠁧󠁢󠁳󠁣󠁴󠁿 Scots Dialogue Converter</h3>
-      <div style={{ fontSize: 10, color: 'var(--dim)', marginBottom: 10, lineHeight: 1.5 }}>
+      <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginBottom: 10, lineHeight: 1.5 }}>
         Convert standard English dialogue into Scots-flavoured speech. Useful for Dreslundic or
         any character with a broad regional accent. Results are a starting point — hand-tune as needed.
       </div>
@@ -1009,7 +1009,7 @@ function ScotsDialogueTool() {
           <label>English dialogue</label>
           <textarea value={input} onChange={e => setInput(e.target.value)} rows={4}
             placeholder={"\"I will not go back there. You know that.\""} 
-            style={{ width: '100%', resize: 'vertical', fontSize: 12, padding: '6px 8px',
+            style={{ width: '100%', resize: 'vertical', fontSize: '0.92em', padding: '6px 8px',
               background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 6,
               color: 'var(--tx)', boxSizing: 'border-box', fontFamily: 'Georgia, serif', lineHeight: 1.6 }} />
         </div>
@@ -1018,10 +1018,10 @@ function ScotsDialogueTool() {
           onClick={convert}>Convert to Scots</button>
         {output && (
           <div>
-            <div style={{ fontSize: 9, color: 'var(--mut)', textTransform: 'uppercase',
+            <div style={{ fontSize: '0.69em', color: 'var(--mut)', textTransform: 'uppercase',
               letterSpacing: '.05em', marginBottom: 4 }}>Result</div>
             <div style={{ padding: '10px 12px', background: 'var(--sf)', border: '1px solid var(--brd)',
-              borderRadius: 6, fontSize: 12, fontFamily: 'Georgia, serif', lineHeight: 1.7,
+              borderRadius: 6, fontSize: '0.92em', fontFamily: 'Georgia, serif', lineHeight: 1.7,
               color: 'var(--tx)', marginBottom: 6, whiteSpace: 'pre-wrap' }}>{output}</div>
             <div style={{ display: 'flex', gap: 6 }}>
               <button className="btn btn-sm btn-outline" onClick={copy}>
@@ -1149,7 +1149,7 @@ function ImageLibraryTool({ db }) {
   return (
     <div className="tool-card" id="tool-imagelib">
       <h3 style={{ color: 'var(--cl)' }}>🖼 Image Library</h3>
-      <div style={{ fontSize: 10, color: 'var(--dim)', marginBottom: 10, lineHeight: 1.5 }}>
+      <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginBottom: 10, lineHeight: 1.5 }}>
         All images from across the Compendium in one place — characters, wardrobe, items, locations,
         maps, manuscript covers and chapter headers. You can also upload images directly here.
       </div>
@@ -1184,7 +1184,7 @@ function ImageLibraryTool({ db }) {
         <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
           {IMG_LIB_CATS.map(c => (
             <button key={c} onClick={() => setFilterCat(c)}
-              style={{ fontSize: 10, padding: '3px 10px', borderRadius: 12, cursor: 'pointer',
+              style={{ fontSize: '0.77em', padding: '3px 10px', borderRadius: 12, cursor: 'pointer',
                 background: filterCat === c ? 'var(--cl)' : 'none',
                 color: filterCat === c ? '#000' : 'var(--dim)',
                 border: `1px solid ${filterCat === c ? 'var(--cl)' : 'var(--brd)'}` }}>
@@ -1194,7 +1194,7 @@ function ImageLibraryTool({ db }) {
         </div>
       </div>
 
-      <div style={{ fontSize: 10, color: 'var(--mut)', marginBottom: 8 }}>
+      <div style={{ fontSize: '0.77em', color: 'var(--mut)', marginBottom: 8 }}>
         {filtered.length} image{filtered.length !== 1 ? 's' : ''}
       </div>
 
@@ -1209,26 +1209,26 @@ function ImageLibraryTool({ db }) {
                 style={{ position: 'absolute', inset: 0, width: '100%', height: '100%',
                   objectFit: 'cover' }}
                 onError={e => e.target.style.display = 'none'} />
-              <div style={{ position: 'absolute', top: 4, right: 4, fontSize: 12,
+              <div style={{ position: 'absolute', top: 4, right: 4, fontSize: '0.92em',
                 background: 'rgba(0,0,0,.6)', borderRadius: 4, padding: '1px 4px',
                 color: '#fff' }}>↗</div>
             </div>
             <div style={{ padding: '5px 7px' }}>
-              <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--tx)',
+              <div style={{ fontSize: '0.77em', fontWeight: 600, color: 'var(--tx)',
                 whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{img.name}</div>
-              <div style={{ fontSize: 9, color: 'var(--cl)' }}>{img.cat}</div>
+              <div style={{ fontSize: '0.69em', color: 'var(--cl)' }}>{img.cat}</div>
             </div>
             {img.direct && (
               <button onClick={() => deleteDirectImage(img.id)}
                 style={{ position: 'absolute', top: 4, left: 4, background: 'rgba(0,0,0,.7)',
                   border: 'none', borderRadius: 4, color: '#ff3355', cursor: 'pointer',
-                  fontSize: 11, padding: '1px 5px', lineHeight: 1 }}>✕</button>
+                  fontSize: '0.85em', padding: '1px 5px', lineHeight: 1 }}>✕</button>
             )}
           </div>
         ))}
         {filtered.length === 0 && (
           <div style={{ gridColumn: '1/-1', textAlign: 'center', padding: '30px 0',
-            color: 'var(--mut)', fontSize: 11 }}>
+            color: 'var(--mut)', fontSize: '0.85em' }}>
             No images found. Upload some or add images to Characters, Wardrobe, Items, or Locations.
           </div>
         )}
@@ -1288,7 +1288,7 @@ function BackfillTool({ db }) {
         Run Backfill
       </button>
       {result !== null && (
-        <div style={{ marginTop:8, fontSize:11, color: result > 0 ? 'var(--sl)' : 'var(--dim)' }}>
+        <div style={{ marginTop:8, fontSize: '0.85em', color: result > 0 ? 'var(--sl)' : 'var(--dim)' }}>
           {result > 0
             ? `✓ Created ${result} birthday event${result !== 1 ? 's' : ''}.`
             : '✓ All birthdays already have timeline entries — nothing to add.'}

--- a/src/tabs/Wiki.jsx
+++ b/src/tabs/Wiki.jsx
@@ -1,10 +1,11 @@
-const SIZE_COLS_WIKI = { XS: 4, S: 3, M: 2, L: 2, XL: 1 }
-
 import { useEffect, useRef, useState } from 'react'
 import Modal from '../components/common/Modal'
 import FilterPopup from '../components/common/FilterPopup'
-import { uid } from '../constants'
+import { TAB_RAINBOW, uid } from '../constants'
 import { scrollAndFlashEntry } from '../components/common/entryNav'
+
+const SIZE_COLS_WIKI = { XS: 4, S: 3, M: 2, L: 2, XL: 1 }
+const tabColor = TAB_RAINBOW['wiki'] || '#aaaaaa'
 
 const WIKI_CATS = [
   'Lore', 'World History', 'Cosmology', 'Power System',
@@ -49,7 +50,7 @@ function FlowchartRenderer({ content }) {
           const outgoing = edges.filter(e => e.from === id)
           return (
             <div key={id} style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-              <div style={{ padding: '4px 12px', background: 'var(--card)', border: '1px solid var(--cc)', borderRadius: 6, fontSize: '0.85em', fontWeight: 600, color: '#ff69b4', whiteSpace: 'nowrap' }}>
+              <div style={{ padding: '4px 12px', background: 'var(--card)', border: '1px solid var(--cc)', borderRadius: 6, fontSize: '0.85em', fontWeight: 600, color: tabColor, whiteSpace: 'nowrap' }}>
                 {nodes[id]}
               </div>
               {outgoing.map((e, i) => (
@@ -78,7 +79,7 @@ function TableRenderer({ content }) {
         <thead>
           <tr>
             {header.map((h, i) => (
-              <th key={i} style={{ padding: '6px 10px', background: 'rgba(201,102,255,.1)', border: '1px solid var(--brd)', color: '#ff69b4', fontWeight: 600, textAlign: 'left' }}>{h}</th>
+              <th key={i} style={{ padding: '6px 10px', background: 'rgba(201,102,255,.1)', border: '1px solid var(--brd)', color: tabColor, fontWeight: 600, textAlign: 'left' }}>{h}</th>
             ))}
           </tr>
         </thead>
@@ -106,7 +107,7 @@ function WikiBlock({ block, onEdit, onDelete, onMoveUp, onMoveDown }) {
         <div style={{ display: 'flex', gap: 3 }}>
           <button className="btn btn-sm btn-outline" style={{ padding: '1px 5px', fontSize: '0.77em' }} onClick={onMoveUp}>↑</button>
           <button className="btn btn-sm btn-outline" style={{ padding: '1px 5px', fontSize: '0.77em' }} onClick={onMoveDown}>↓</button>
-          <button className="btn btn-sm btn-outline" style={{ color: '#ff69b4', borderColor: 'var(--cc)', padding: '1px 5px', fontSize: '0.77em' }} onClick={onEdit}>✎</button>
+          <button className="btn btn-sm btn-outline" style={{ color: tabColor, borderColor: tabColor, padding: '1px 5px', fontSize: '0.77em' }} onClick={onEdit}>✎</button>
           <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544', padding: '1px 5px', fontSize: '0.77em' }} onClick={onDelete}>✕</button>
         </div>
       </div>
@@ -157,7 +158,7 @@ function BlockEditor({ block, onSave, onClose }) {
   }
 
   return (
-    <Modal open onClose={onClose} title={block ? 'Edit Block' : 'Add Block'} color="var(--cc)">
+    <Modal open onClose={onClose} title={block ? 'Edit Block' : 'Add Block'} color={tabColor}>
       <div className="field">
         <label>Block Type</label>
         <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
@@ -165,7 +166,7 @@ function BlockEditor({ block, onSave, onClose }) {
             <button
               key={ct.k}
               className={`fp ${type === ct.k ? 'active' : ''}`}
-              style={{ color: '#ff69b4' }}
+              style={{ color: tabColor }}
               onClick={() => setType(ct.k)}
             >{ct.l}</button>
           ))}
@@ -201,7 +202,7 @@ function BlockEditor({ block, onSave, onClose }) {
 
       <div className="modal-actions">
         <button className="btn btn-outline" onClick={onClose}>Cancel</button>
-        <button className="btn btn-primary" style={{ background: '#ff69b4' }} onClick={() => onSave({ ...block, id: block?.id || uid(), type, content, caption })}>
+        <button className="btn btn-primary" style={{ background: tabColor }} onClick={() => onSave({ ...block, id: block?.id || uid(), type, content, caption })}>
           {block?.id ? 'Save' : 'Add Block'}
         </button>
       </div>
@@ -243,10 +244,10 @@ function ArticleEditor({ article, onSave, onCancel }) {
     <div>
       <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 12, flexWrap: 'wrap' }}>
         <button className="btn btn-sm btn-outline" onClick={onCancel}>← Back</button>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1em', color: '#ff69b4', flex: 1 }}>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1em', color: tabColor, flex: 1 }}>
           {article?.id ? 'Editing Article' : 'New Article'}
         </div>
-        <button className="btn btn-primary btn-sm" style={{ background: '#ff69b4' }} onClick={() => onSave({ ...article, id: article?.id || uid(), title, category, summary, blocks, updated: new Date().toISOString() })}>
+        <button className="btn btn-primary btn-sm" style={{ background: tabColor }} onClick={() => onSave({ ...article, id: article?.id || uid(), title, category, summary, blocks, updated: new Date().toISOString() })}>
           Save Article
         </button>
       </div>
@@ -263,7 +264,7 @@ function ArticleEditor({ article, onSave, onCancel }) {
 
       {/* Blocks */}
       <div style={{ marginTop: 12 }}>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '0.92em', color: '#ff69b4', marginBottom: 8 }}>Content Blocks</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '0.92em', color: tabColor, marginBottom: 8 }}>Content Blocks</div>
         {!blocks.length && (
           <div style={{ textAlign: 'center', padding: '20px', color: 'var(--mut)', fontSize: '0.85em', border: '1px dashed var(--brd)', borderRadius: 'var(--r)' }}>
             No blocks yet. Add your first content block below.
@@ -281,7 +282,7 @@ function ArticleEditor({ article, onSave, onCancel }) {
         ))}
         <button
           className="btn btn-outline"
-          style={{ width: '100%', borderStyle: 'dashed', color: '#ff69b4', borderColor: 'var(--cc)', marginTop: 4 }}
+          style={{ width: '100%', borderStyle: 'dashed', color: tabColor, borderColor: tabColor, marginTop: 4 }}
           onClick={() => setAddingBlock(true)}
         >+ Add Block</button>
       </div>
@@ -346,14 +347,14 @@ export default function Wiki({ db, navSearch }) {
           {['XS','S','M','L','XL'].map(sz => (
             <button key={sz} onClick={() => changeColSize(sz)}
               style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, cursor: 'pointer',
-                background: colSize === sz ? '#ff69b4' : 'none',
+                background: colSize === sz ? tabColor : 'none',
                 color: colSize === sz ? '#000' : 'var(--dim)',
-                border: `1px solid ${colSize === sz ? '#ff69b4' : 'var(--brd)'}` }}>{sz}</button>
+                border: `1px solid ${colSize === sz ? tabColor : 'var(--brd)'}` }}>{sz}</button>
           ))}
         </div>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.15em', color: '#ff69b4' }}>📖 Wiki</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.15em', color: tabColor }}>📖 Wiki</div>
         <FilterPopup
-          color="#ff69b4"
+          color={tabColor}
           filters={[{ key: 'category', label: 'Category', options: WIKI_CATS.map(c => ({ value: c, label: c })) }]}
           values={filterValues}
           onChange={(key, vals) => setFilterValues(prev => ({ ...prev, [key]: vals }))}
@@ -363,14 +364,14 @@ export default function Wiki({ db, navSearch }) {
             📥 Auto-imported ({autoCount})
           </button>
         )}
-        <button className="btn btn-primary btn-sm" style={{ background: '#ff69b4' }} onClick={() => setEditing({})}>+ New Article</button>
+        <button className="btn btn-primary btn-sm" style={{ background: tabColor }} onClick={() => setEditing({})}>+ New Article</button>
       </div>
 
       {/* Category filter */}
       <div style={{ display: 'flex', gap: 3, flexWrap: 'wrap', marginBottom: 10 }}>
-        <button className={`fp ${catFilter==='all'?'active':''}`} style={{ color: '#ff69b4' }} onClick={() => setCatFilter('all')}>All</button>
+        <button className={`fp ${catFilter==='all'?'active':''}`} style={{ color: tabColor }} onClick={() => setCatFilter('all')}>All</button>
         {WIKI_CATS.filter(c => articles.some(a => a.category === c)).map(c => (
-          <button key={c} className={`fp ${catFilter===c?'active':''}`} style={{ color: '#ff69b4' }} onClick={() => setCatFilter(c)}>{c}</button>
+          <button key={c} className={`fp ${catFilter===c?'active':''}`} style={{ color: tabColor }} onClick={() => setCatFilter(c)}>{c}</button>
         ))}
       </div>
 
@@ -381,25 +382,25 @@ export default function Wiki({ db, navSearch }) {
           <p style={{ fontSize: '0.85em', color: 'var(--mut)', maxWidth: 300, margin: '8px auto' }}>
             The wiki is where long-form lore lives — world history, cosmology, power system deep-dives, cultures, languages, factions. Supports text, tables, flowcharts, diagrams, images, and callouts.
           </p>
-          <button className="btn btn-primary" style={{ background: '#ff69b4' }} onClick={() => setEditing({})}>+ New Article</button>
+          <button className="btn btn-primary" style={{ background: tabColor }} onClick={() => setEditing({})}>+ New Article</button>
         </div>
       )}
 
       <div style={{ display: 'grid', gridTemplateColumns: {'XS':4,'S':3,'M':2,'L':1,'XL':1}[colSize] || 2 > 1 ? `repeat(${ {'XS':4,'S':3,'M':2,'L':1,'XL':1}[colSize] || 2 }, minmax(0,1fr))` : '1fr', gap: 6 }}>
         {filtered.map(a => (
-          <div key={a.id} id={`gcomp-entry-${a.id}`} className="entry-card" style={{ '--card-color': '#ff69b4' }}>
+          <div key={a.id} id={`gcomp-entry-${a.id}`} className="entry-card" style={{ '--card-color': tabColor }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
               <div>
                 <div className="entry-title">{a.title}</div>
                 {a.summary && <div style={{ fontSize: '0.85em', color: 'var(--dim)', marginTop: 2 }}>{a.summary}</div>}
               </div>
-              <span className="badge" style={{ color: '#ff69b4', borderColor: 'rgba(201,102,255,.3)', flexShrink: 0, marginLeft: 8 }}>{a.category}</span>
+              <span className="badge" style={{ color: tabColor, borderColor: 'rgba(201,102,255,.3)', flexShrink: 0, marginLeft: 8 }}>{a.category}</span>
             </div>
             <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 4 }}>
               {a.blocks?.length || 0} block{(a.blocks?.length || 0) !== 1 ? 's' : ''} · Updated {a.updated ? new Date(a.updated).toLocaleDateString() : '—'}
             </div>
             <div className="entry-actions" style={{ marginTop: 6 }}>
-              <button className="btn btn-sm btn-outline" style={{ color: '#ff69b4', borderColor: 'var(--cc)' }} onClick={() => setEditing(a)}>✎ Edit</button>
+              <button className="btn btn-sm btn-outline" style={{ color: tabColor, borderColor: tabColor }} onClick={() => setEditing(a)}>✎ Edit</button>
               <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544' }} onClick={() => setConfirmId(a.id)}>✕</button>
             </div>
           </div>

--- a/src/tabs/Wiki.jsx
+++ b/src/tabs/Wiki.jsx
@@ -41,7 +41,7 @@ function FlowchartRenderer({ content }) {
     if (!nodes[e.to]) nodes[e.to] = e.to
   })
   const nodeIds = Object.keys(nodes)
-  if (!nodeIds.length) return <div style={{ color: 'var(--mut)', fontSize: 11, fontStyle: 'italic' }}>No flowchart nodes defined</div>
+  if (!nodeIds.length) return <div style={{ color: 'var(--mut)', fontSize: '0.85em', fontStyle: 'italic' }}>No flowchart nodes defined</div>
   return (
     <div style={{ overflowX: 'auto', padding: '8px 0' }}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-start' }}>
@@ -49,13 +49,13 @@ function FlowchartRenderer({ content }) {
           const outgoing = edges.filter(e => e.from === id)
           return (
             <div key={id} style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-              <div style={{ padding: '4px 12px', background: 'var(--card)', border: '1px solid var(--cc)', borderRadius: 6, fontSize: 11, fontWeight: 600, color: '#ff69b4', whiteSpace: 'nowrap' }}>
+              <div style={{ padding: '4px 12px', background: 'var(--card)', border: '1px solid var(--cc)', borderRadius: 6, fontSize: '0.85em', fontWeight: 600, color: '#ff69b4', whiteSpace: 'nowrap' }}>
                 {nodes[id]}
               </div>
               {outgoing.map((e, i) => (
-                <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 4, color: 'var(--dim)', fontSize: 10 }}>
+                <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 4, color: 'var(--dim)', fontSize: '0.77em' }}>
                   <span>→{e.label ? ` (${e.label})` : ''}</span>
-                  <div style={{ padding: '4px 12px', background: 'var(--card)', border: '1px solid var(--cl)', borderRadius: 6, fontSize: 11, color: 'var(--cl)', whiteSpace: 'nowrap' }}>{nodes[e.to] || e.to}</div>
+                  <div style={{ padding: '4px 12px', background: 'var(--card)', border: '1px solid var(--cl)', borderRadius: 6, fontSize: '0.85em', color: 'var(--cl)', whiteSpace: 'nowrap' }}>{nodes[e.to] || e.to}</div>
                 </div>
               ))}
             </div>
@@ -69,12 +69,12 @@ function FlowchartRenderer({ content }) {
 // ── Table renderer ──────────────────────────────────────────────
 function TableRenderer({ content }) {
   const rows = (content || '').split('\n').map(r => r.split('|').map(c => c.trim()).filter(Boolean))
-  if (!rows.length || !rows[0].length) return <div style={{ color: 'var(--mut)', fontSize: 11, fontStyle: 'italic' }}>No table data</div>
+  if (!rows.length || !rows[0].length) return <div style={{ color: 'var(--mut)', fontSize: '0.85em', fontStyle: 'italic' }}>No table data</div>
   const header = rows[0]
   const body = rows.slice(1).filter(r => !r.every(c => /^[-:]+$/.test(c)))
   return (
     <div style={{ overflowX: 'auto', marginTop: 6 }}>
-      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 11 }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85em' }}>
         <thead>
           <tr>
             {header.map((h, i) => (
@@ -102,31 +102,31 @@ function WikiBlock({ block, onEdit, onDelete, onMoveUp, onMoveDown }) {
   return (
     <div style={{ marginBottom: 12, padding: 10, background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 'var(--r)' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 6 }}>
-        <span style={{ fontSize: 9, color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '.06em' }}>{type}</span>
+        <span style={{ fontSize: '0.69em', color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '.06em' }}>{type}</span>
         <div style={{ display: 'flex', gap: 3 }}>
-          <button className="btn btn-sm btn-outline" style={{ padding: '1px 5px', fontSize: 10 }} onClick={onMoveUp}>↑</button>
-          <button className="btn btn-sm btn-outline" style={{ padding: '1px 5px', fontSize: 10 }} onClick={onMoveDown}>↓</button>
-          <button className="btn btn-sm btn-outline" style={{ color: '#ff69b4', borderColor: 'var(--cc)', padding: '1px 5px', fontSize: 10 }} onClick={onEdit}>✎</button>
-          <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544', padding: '1px 5px', fontSize: 10 }} onClick={onDelete}>✕</button>
+          <button className="btn btn-sm btn-outline" style={{ padding: '1px 5px', fontSize: '0.77em' }} onClick={onMoveUp}>↑</button>
+          <button className="btn btn-sm btn-outline" style={{ padding: '1px 5px', fontSize: '0.77em' }} onClick={onMoveDown}>↓</button>
+          <button className="btn btn-sm btn-outline" style={{ color: '#ff69b4', borderColor: 'var(--cc)', padding: '1px 5px', fontSize: '0.77em' }} onClick={onEdit}>✎</button>
+          <button className="btn btn-sm btn-outline" style={{ color: '#ff3355', borderColor: '#ff335544', padding: '1px 5px', fontSize: '0.77em' }} onClick={onDelete}>✕</button>
         </div>
       </div>
 
       {type === 'text' && (
-        <div style={{ fontSize: 12, color: 'var(--tx)', lineHeight: 1.6, whiteSpace: 'pre-wrap' }}>{content}</div>
+        <div style={{ fontSize: '0.92em', color: 'var(--tx)', lineHeight: 1.6, whiteSpace: 'pre-wrap' }}>{content}</div>
       )}
       {type === 'table' && <TableRenderer content={content} />}
       {type === 'flowchart' && <FlowchartRenderer content={content} />}
       {type === 'diagram' && (
-        <div style={{ padding: 10, background: 'rgba(0,0,0,.2)', borderRadius: 4, fontFamily: 'monospace', fontSize: 11, color: 'var(--cl)', whiteSpace: 'pre-wrap' }}>{content}</div>
+        <div style={{ padding: 10, background: 'rgba(0,0,0,.2)', borderRadius: 4, fontFamily: 'monospace', fontSize: '0.85em', color: 'var(--cl)', whiteSpace: 'pre-wrap' }}>{content}</div>
       )}
       {type === 'image' && content && (
         <div style={{ textAlign: 'center' }}>
           <img src={content} alt={caption || ''} style={{ maxWidth: '100%', borderRadius: 4, border: '1px solid var(--brd)' }} />
-          {caption && <div style={{ fontSize: 10, color: 'var(--dim)', marginTop: 4, fontStyle: 'italic' }}>{caption}</div>}
+          {caption && <div style={{ fontSize: '0.77em', color: 'var(--dim)', marginTop: 4, fontStyle: 'italic' }}>{caption}</div>}
         </div>
       )}
       {type === 'callout' && (
-        <div style={{ padding: '8px 12px', background: 'rgba(201,102,255,.08)', border: '1px solid rgba(201,102,255,.3)', borderLeft: '3px solid var(--cc)', borderRadius: 4, fontSize: 11, color: 'var(--tx)', lineHeight: 1.5 }}>
+        <div style={{ padding: '8px 12px', background: 'rgba(201,102,255,.08)', border: '1px solid rgba(201,102,255,.3)', borderLeft: '3px solid var(--cc)', borderRadius: 4, fontSize: '0.85em', color: 'var(--tx)', lineHeight: 1.5 }}>
           {content}
         </div>
       )}
@@ -175,7 +175,7 @@ function BlockEditor({ block, onSave, onClose }) {
       {type === 'image' ? (
         <div className="field">
           <label>Image</label>
-          <label style={{ display: 'inline-block', padding: '6px 12px', background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 'var(--r)', cursor: 'pointer', fontSize: 11 }}>
+          <label style={{ display: 'inline-block', padding: '6px 12px', background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 'var(--r)', cursor: 'pointer', fontSize: '0.85em' }}>
             📎 Upload Image
             <input ref={imgRef} type="file" accept="image/*" style={{ display: 'none' }} onChange={handleImageUpload} />
           </label>
@@ -194,8 +194,8 @@ function BlockEditor({ block, onSave, onClose }) {
             placeholder={placeholders[type] || ''}
             style={{ minHeight: type === 'text' ? 120 : 80 }}
           />
-          {type === 'table' && <div style={{ fontSize: 9, color: 'var(--mut)', marginTop: 2 }}>Use | to separate columns, --- for header divider</div>}
-          {type === 'flowchart' && <div style={{ fontSize: 9, color: 'var(--mut)', marginTop: 2 }}>Format: NodeA [Label] on its own line, then NodeA --&gt; NodeB : label</div>}
+          {type === 'table' && <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 2 }}>Use | to separate columns, --- for header divider</div>}
+          {type === 'flowchart' && <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 2 }}>Format: NodeA [Label] on its own line, then NodeA --&gt; NodeB : label</div>}
         </div>
       )}
 
@@ -243,7 +243,7 @@ function ArticleEditor({ article, onSave, onCancel }) {
     <div>
       <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 12, flexWrap: 'wrap' }}>
         <button className="btn btn-sm btn-outline" onClick={onCancel}>← Back</button>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: 13, color: '#ff69b4', flex: 1 }}>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1em', color: '#ff69b4', flex: 1 }}>
           {article?.id ? 'Editing Article' : 'New Article'}
         </div>
         <button className="btn btn-primary btn-sm" style={{ background: '#ff69b4' }} onClick={() => onSave({ ...article, id: article?.id || uid(), title, category, summary, blocks, updated: new Date().toISOString() })}>
@@ -263,9 +263,9 @@ function ArticleEditor({ article, onSave, onCancel }) {
 
       {/* Blocks */}
       <div style={{ marginTop: 12 }}>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: 12, color: '#ff69b4', marginBottom: 8 }}>Content Blocks</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '0.92em', color: '#ff69b4', marginBottom: 8 }}>Content Blocks</div>
         {!blocks.length && (
-          <div style={{ textAlign: 'center', padding: '20px', color: 'var(--mut)', fontSize: 11, border: '1px dashed var(--brd)', borderRadius: 'var(--r)' }}>
+          <div style={{ textAlign: 'center', padding: '20px', color: 'var(--mut)', fontSize: '0.85em', border: '1px dashed var(--brd)', borderRadius: 'var(--r)' }}>
             No blocks yet. Add your first content block below.
           </div>
         )}
@@ -351,7 +351,7 @@ export default function Wiki({ db, navSearch }) {
                 border: `1px solid ${colSize === sz ? '#ff69b4' : 'var(--brd)'}` }}>{sz}</button>
           ))}
         </div>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: 15, color: '#ff69b4' }}>📖 Wiki</div>
+        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.15em', color: '#ff69b4' }}>📖 Wiki</div>
         <FilterPopup
           color="#ff69b4"
           filters={[{ key: 'category', label: 'Category', options: WIKI_CATS.map(c => ({ value: c, label: c })) }]}
@@ -378,7 +378,7 @@ export default function Wiki({ db, navSearch }) {
         <div className="empty">
           <div className="empty-icon">📖</div>
           <p>No wiki articles yet.</p>
-          <p style={{ fontSize: 11, color: 'var(--mut)', maxWidth: 300, margin: '8px auto' }}>
+          <p style={{ fontSize: '0.85em', color: 'var(--mut)', maxWidth: 300, margin: '8px auto' }}>
             The wiki is where long-form lore lives — world history, cosmology, power system deep-dives, cultures, languages, factions. Supports text, tables, flowcharts, diagrams, images, and callouts.
           </p>
           <button className="btn btn-primary" style={{ background: '#ff69b4' }} onClick={() => setEditing({})}>+ New Article</button>
@@ -391,11 +391,11 @@ export default function Wiki({ db, navSearch }) {
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
               <div>
                 <div className="entry-title">{a.title}</div>
-                {a.summary && <div style={{ fontSize: 11, color: 'var(--dim)', marginTop: 2 }}>{a.summary}</div>}
+                {a.summary && <div style={{ fontSize: '0.85em', color: 'var(--dim)', marginTop: 2 }}>{a.summary}</div>}
               </div>
               <span className="badge" style={{ color: '#ff69b4', borderColor: 'rgba(201,102,255,.3)', flexShrink: 0, marginLeft: 8 }}>{a.category}</span>
             </div>
-            <div style={{ fontSize: 9, color: 'var(--mut)', marginTop: 4 }}>
+            <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 4 }}>
               {a.blocks?.length || 0} block{(a.blocks?.length || 0) !== 1 ? 's' : ''} · Updated {a.updated ? new Date(a.updated).toLocaleDateString() : '—'}
             </div>
             <div className="entry-actions" style={{ marginTop: 6 }}>

--- a/src/tabs/World.jsx
+++ b/src/tabs/World.jsx
@@ -1,4 +1,5 @@
 import GenericListTab from '../components/common/GenericListTab'
+import { TAB_RAINBOW } from '../constants'
 
 const WORLD_FIELDS = [
   { k: 'name', l: 'Topic', t: 'text', r: true },
@@ -10,12 +11,15 @@ export default function World({ db, navSearch }) {
   return (
     <GenericListTab
       catKey="world"
-      color="#ff8c00"
+      color={TAB_RAINBOW.world}
       icon="🌐"
       label="World Entries"
       fields={WORLD_FIELDS}
       db={db}
       navSearch={navSearch}
+      getJumpName={e => e.name}
+      entityKey="world"
+      tabColor={TAB_RAINBOW.world}
     />
   )
 }

--- a/src/tabs/notes/IdeasView.jsx
+++ b/src/tabs/notes/IdeasView.jsx
@@ -1,0 +1,147 @@
+import { useEffect, useMemo, useState } from 'react'
+import { TAB_RAINBOW, uid } from '../../constants'
+import { supabase, hasSupabase } from '../../supabase'
+import { IDEAS_CATEGORIES, IDEAS_LS_KEY, lsGet, lsSet } from './stickyShared'
+
+const NOTES_COLOR = TAB_RAINBOW.notes
+const COLS_MAP = { XS: 5, S: 4, M: 3, L: 2, XL: 1 }
+const CAT_COLORS = { names: '#ff6b6b', words: '#44aaff', phrases: '#44bb44' }
+
+export default function IdeasView({ db, pendingExpandId, clearPendingExpandId }) {
+  const [ideas, setIdeas] = useState(() => db.db.ideas_list || lsGet(IDEAS_LS_KEY, []))
+  const [search, setSearch] = useState('')
+  const [sortMode, setSortMode] = useState('newest')
+  const [catFilter, setCatFilter] = useState('all')
+  const [draftValue, setDraftValue] = useState('')
+  const [draftCategory, setDraftCategory] = useState('names')
+  const [editingId, setEditingId] = useState(null)
+  const [editValue, setEditValue] = useState('')
+  const [cols, setCols] = useState(() => {
+    try { return localStorage.getItem('ideas_list_cols') || 'M' } catch { return 'M' }
+  })
+
+  useEffect(() => { setIdeas(db.db.ideas_list || []) }, [db.db.ideas_list])
+  useEffect(() => { lsSet(IDEAS_LS_KEY, ideas) }, [ideas])
+
+  useEffect(() => {
+    if (!pendingExpandId) return
+    const found = ideas.find(i => i.id === pendingExpandId)
+    if (!found) return
+    setEditingId(found.id)
+    setEditValue(found.value || '')
+    clearPendingExpandId?.()
+  }, [pendingExpandId, ideas, clearPendingExpandId])
+
+  function setColsPersist(v) {
+    setCols(v)
+    try { localStorage.setItem('ideas_list_cols', v) } catch {}
+  }
+
+  async function addIdea() {
+    const value = draftValue.trim()
+    if (!value) return
+    const entry = { id: uid(), category: draftCategory, value, created_at: new Date().toISOString() }
+    setIdeas(prev => [entry, ...prev])
+    setDraftValue('')
+    if (!hasSupabase || !supabase) return
+    try { await supabase.from('ideas_list').insert(entry) } catch {}
+  }
+
+  async function saveIdea(id) {
+    const value = editValue.trim()
+    if (!value) return
+    const entry = ideas.find(i => i.id === id)
+    if (!entry) return
+    const updated = { ...entry, value }
+    setIdeas(prev => prev.map(i => i.id === id ? updated : i))
+    setEditingId(null)
+    if (!hasSupabase || !supabase) return
+    try { await supabase.from('ideas_list').upsert(updated, { onConflict: 'id' }) } catch {}
+  }
+
+  async function deleteIdea(id) {
+    setIdeas(prev => prev.filter(i => i.id !== id))
+    if (!hasSupabase || !supabase) return
+    try { await supabase.from('ideas_list').delete().eq('id', id) } catch {}
+  }
+
+  const filtered = useMemo(() => {
+    const list = ideas.filter(i => {
+      const matchSearch = !search || (i.value || '').toLowerCase().includes(search.toLowerCase())
+      const matchCat = catFilter === 'all' || i.category === catFilter
+      return matchSearch && matchCat
+    })
+    list.sort((a, b) => {
+      if (sortMode === 'oldest') return new Date(a.created_at || 0) - new Date(b.created_at || 0)
+      if (sortMode === 'alpha') return (a.value || '').localeCompare(b.value || '')
+      return new Date(b.created_at || 0) - new Date(a.created_at || 0)
+    })
+    return list
+  }, [ideas, search, catFilter, sortMode])
+
+  return (
+    <div>
+      <div className="tbar" style={{ flexWrap: 'wrap', gap: 6 }}>
+        <div style={{ display: 'flex', gap: 3 }}>
+          {['XS', 'S', 'M', 'L', 'XL'].map(l => (
+            <button key={l} onClick={() => setColsPersist(l)} style={{ fontSize: '0.77em', padding: '2px 7px', borderRadius: 4, border: `1px solid ${cols === l ? NOTES_COLOR : 'var(--brd)'}`, background: cols === l ? `${NOTES_COLOR}22` : 'transparent', color: cols === l ? NOTES_COLOR : 'var(--dim)', cursor: 'pointer' }}>{l}</button>
+          ))}
+        </div>
+        <input className="sx" placeholder="Search ideas..." value={search} onChange={e => setSearch(e.target.value)} />
+        <select value={sortMode} onChange={e => setSortMode(e.target.value)} style={{ fontSize: '0.85em', padding: '4px 8px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
+          <option value="newest">Newest</option>
+          <option value="oldest">Oldest</option>
+          <option value="alpha">A-Z</option>
+        </select>
+        <select value={catFilter} onChange={e => setCatFilter(e.target.value)} style={{ fontSize: '0.85em', padding: '4px 8px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
+          <option value="all">All</option>
+          {IDEAS_CATEGORIES.map(cat => <option key={cat.id} value={cat.id}>{cat.label}</option>)}
+        </select>
+      </div>
+
+      <div style={{ background: 'var(--card)', border: '1px solid var(--brd)', borderRadius: 8, padding: 10, marginBottom: 12 }}>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          <select value={draftCategory} onChange={e => setDraftCategory(e.target.value)} style={{ minWidth: 120, padding: '6px 8px', fontSize: '0.85em', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }}>
+            {IDEAS_CATEGORIES.map(cat => <option key={cat.id} value={cat.id}>{cat.label}</option>)}
+          </select>
+          <input value={draftValue} onChange={e => setDraftValue(e.target.value)} onKeyDown={e => e.key === 'Enter' && addIdea()} placeholder="Add a new idea..." style={{ flex: 1, minWidth: 220, padding: '6px 8px', fontSize: '0.92em', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)' }} />
+          <button onClick={addIdea} style={{ padding: '6px 12px', borderRadius: 6, border: `1px solid ${NOTES_COLOR}`, background: 'transparent', color: NOTES_COLOR, fontSize: '0.85em', cursor: 'pointer' }}>+ Add</button>
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: `repeat(${COLS_MAP[cols] || 3}, 1fr)`, gap: 8 }}>
+        {filtered.map(idea => {
+          const color = CAT_COLORS[idea.category] || NOTES_COLOR
+          const editing = editingId === idea.id
+          return (
+            <div key={idea.id} id={`gcomp-entry-${idea.id}`} style={{ background: 'var(--card)', border: '1px solid var(--brd)', borderLeft: `3px solid ${color}`, borderRadius: 8, padding: 10 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'flex-start' }}>
+                <span style={{ fontSize: '0.69em', padding: '2px 6px', borderRadius: 999, background: `${color}22`, color, border: `1px solid ${color}55` }}>
+                  {IDEAS_CATEGORIES.find(c => c.id === idea.category)?.label || idea.category}
+                </span>
+                <div style={{ display: 'flex', gap: 4 }}>
+                  <button onClick={() => { setEditingId(idea.id); setEditValue(idea.value || '') }} style={{ fontSize: '0.85em', border: 'none', background: 'none', color, cursor: 'pointer' }}>✎</button>
+                  <button onClick={() => deleteIdea(idea.id)} style={{ fontSize: '0.85em', border: 'none', background: 'none', color: '#ff3355', cursor: 'pointer' }}>✕</button>
+                </div>
+              </div>
+              {editing ? (
+                <div style={{ marginTop: 8 }}>
+                  <textarea value={editValue} onChange={e => setEditValue(e.target.value)} style={{ width: '100%', minHeight: 90, padding: '6px 8px', fontSize: '0.92em', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', boxSizing: 'border-box' }} />
+                  <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
+                    <button onClick={() => saveIdea(idea.id)} style={{ padding: '5px 10px', borderRadius: 6, border: `1px solid ${color}`, background: 'transparent', color, fontSize: '0.85em', cursor: 'pointer' }}>Save</button>
+                    <button onClick={() => setEditingId(null)} style={{ padding: '5px 10px', borderRadius: 6, border: '1px solid var(--brd)', background: 'transparent', color: 'var(--dim)', fontSize: '0.85em', cursor: 'pointer' }}>Cancel</button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div style={{ marginTop: 8, fontSize: '0.92em', color: 'var(--tx)', lineHeight: 1.5, whiteSpace: 'pre-wrap' }}>{idea.value}</div>
+                  <div style={{ marginTop: 8, fontSize: '0.69em', color: 'var(--mut)' }}>{idea.created_at ? new Date(idea.created_at).toLocaleString() : ''}</div>
+                </>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/tabs/notes/JournalView.jsx
+++ b/src/tabs/notes/JournalView.jsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useState } from 'react'
 import Modal from '../../components/common/Modal'
-import { uid } from '../../constants'
+import { TAB_RAINBOW, uid } from '../../constants'
 import StickyEditModal from './StickyEditModal'
-import { NOTES_COLOR, normalizeSticky, scrollAndFlashEntry, sortJournalPins, STICKY_COLORS } from './stickyShared'
+import { normalizeSticky, scrollAndFlashEntry, sortJournalPins, STICKY_COLORS, stickyTilt } from './stickyShared'
+
+const NOTES_COLOR = TAB_RAINBOW.notes
 
 const SIZE_COLS_N = { XS: 4, S: 3, M: 2, L: 1, XL: 1 }
-const SIZE_LABELS_N = ['XS', 'S', 'M', 'L']
+const SIZE_LABELS_N = ['XS', 'S', 'M', 'L', 'XL']
 const NOTE_CATS = ['General', 'Canon', 'Brainstorm', 'Research', 'Todo', 'Quote', 'Other']
 
 function NoteForm({ note, onSave, onCancel, cats }) {
@@ -66,7 +68,7 @@ export default function JournalView({ db, navSearch, pendingExpandId, clearPendi
   }).sort((a, b) => new Date(b.updated || 0) - new Date(a.updated || 0))
 
   const usedCats = [...new Set(notes.map(n => n.category).filter(Boolean))]
-  const pinnedStickies = sortJournalPins(captures.filter(c => c.pinned_journal))
+  const pinnedStickies = sortJournalPins(captures.filter(c => c.pinned_journal && !c.archived))
   const isMobile = typeof window !== 'undefined' ? window.innerWidth < 700 : false
 
   function changeColSize(sz) { setColSize(sz); try { localStorage.setItem('colsize_notes', sz) } catch {} }
@@ -105,7 +107,9 @@ export default function JournalView({ db, navSearch, pendingExpandId, clearPendi
             <button key={l} onClick={() => changeColSize(l)} style={{ fontSize: '0.69em', padding: '2px 7px', borderRadius: 8, background: colSize === l ? NOTES_COLOR : 'none', color: colSize === l ? '#000' : 'var(--dim)', border: `1px solid ${colSize === l ? NOTES_COLOR : 'var(--brd)'}`, cursor: 'pointer' }}>{l}</button>
           ))}
         </div>
-        <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.08em', color: NOTES_COLOR }}>📝 Journal</div>
+        <div style={{ display: 'flex', justifyContent: 'flex-start', flex: 1 }}>
+          <div style={{ fontFamily: "'Cinzel', serif", fontSize: '1.08em', color: NOTES_COLOR }}>📝 Journal</div>
+        </div>
         <button className="btn btn-primary btn-sm" style={{ background: NOTES_COLOR, color: '#000' }} onClick={() => { setEditing({}); setModalOpen(true) }}>+ New Note</button>
       </div>
 
@@ -167,6 +171,7 @@ export default function JournalView({ db, navSearch, pendingExpandId, clearPendi
             )}
             {pinnedStickies.map(sticky => {
               const sc = STICKY_COLORS.find(c => c.id === sticky.color) || STICKY_COLORS[0]
+              const tilt = stickyTilt(sticky.id)
               return (
                 <div
                   key={sticky.id}
@@ -174,16 +179,21 @@ export default function JournalView({ db, navSearch, pendingExpandId, clearPendi
                   onDragStart={() => setDragId(sticky.id)}
                   onDragOver={e => e.preventDefault()}
                   onDrop={() => handleSidebarDrop(sticky.id)}
-                  style={{ padding: '8px 10px', borderRadius: 8, background: 'var(--sf)', border: '1px solid var(--brd)', marginBottom: 6 }}
+                  style={{ width: 120, minHeight: 120, padding: 10, borderRadius: 6, background: sticky.customBg || sc.bg, border: `1px solid ${sticky.customBorder || sc.border}`, marginBottom: 8, transform: `rotate(${tilt}deg)`, boxShadow: '2px 4px 10px rgba(0,0,0,.16)', cursor: 'pointer' }}
+                  onClick={() => setSidebarEdit(sticky)}
+                  title={sticky.text}
                 >
-                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
-                    <span style={{ width: 10, height: 10, borderRadius: '50%', background: sticky.customBg || sc.border, marginTop: 4, flexShrink: 0 }} />
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontSize: '0.8em', color: 'var(--tx)', lineHeight: 1.4, display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 6 }}>
+                    <span style={{ width: 10, height: 10, borderRadius: '50%', background: sc.border, flexShrink: 0 }} />
+                    <button className="btn btn-sm btn-outline" onClick={e => { e.stopPropagation(); setSidebarEdit(sticky) }}>✎</button>
+                  </div>
+                  <div style={{ marginTop: 8 }}>
+                    <div style={{ fontSize: '0.8em', color: sticky.customText || sc.text, lineHeight: 1.35, display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
                         {sticky.text}
-                      </div>
                     </div>
-                    <button className="btn btn-sm btn-outline" onClick={() => setSidebarEdit(sticky)}>✎</button>
+                    <div style={{ fontSize: '0.69em', color: sticky.customText || sc.text, opacity: 0.65, marginTop: 6 }}>
+                      {sticky.created ? new Date(sticky.created).toLocaleDateString() : ''}
+                    </div>
                   </div>
                 </div>
               )

--- a/src/tabs/notes/StickiesView.jsx
+++ b/src/tabs/notes/StickiesView.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { uid } from '../../constants'
+import { TAB_RAINBOW, uid } from '../../constants'
 import { supabase, hasSupabase } from '../../supabase'
 import StickyEditModal from './StickyEditModal'
 import {
@@ -18,7 +18,8 @@ import {
   stickyTitle,
 } from './stickyShared'
 
-const JOURNAL_COLOR = '#38b000'
+const JOURNAL_COLOR = TAB_RAINBOW.notes
+const STICKY_COLS = { XS: 6, S: 5, M: 4, L: 3, XL: 2 }
 
 const SEND_GROUPS = [
   { label: 'STORY', items: [['characters', 'Characters'], ['locations', 'Locations'], ['items', 'Items'], ['scenes', 'Scenes'], ['timeline', 'Timeline']] },
@@ -43,9 +44,22 @@ function QuickCapture({ tags, onAddSticky, onOpenLongForm }) {
     return () => document.removeEventListener('mousedown', onDocClick)
   }, [menuOpen])
 
+  const charCount = text.length
+
+  function inferredSize() {
+    if (charCount > 600) return 'large'
+    if (charCount > 300) return 'normal'
+    return 'small'
+  }
+
   function submitSticky() {
     if (!text.trim()) return
-    onAddSticky({ text: text.trim(), tag, color, size: 'normal', pinned_stickies: false, pinned_journal: false })
+    if (text.trim().length > 1000 && quickMode === 'sticky') {
+      onOpenLongForm(text.trim(), true)
+      setText('')
+      return
+    }
+    onAddSticky({ text: text.trim(), tag, color, size: inferredSize(), pinned_stickies: false, pinned_journal: false })
     setText('')
   }
 
@@ -92,12 +106,12 @@ function QuickCapture({ tags, onAddSticky, onOpenLongForm }) {
         <select value={color} onChange={e => setColor(e.target.value)} style={{ fontSize: '0.77em', padding: '3px 6px', background: 'var(--sf)', border: '1px solid var(--brd)', borderRadius: 6, color: 'var(--tx)', flex: 1, minWidth: 80 }}>
           {STICKY_COLORS.map(c => <option key={c.id} value={c.id}>{c.label}</option>)}
         </select>
-        <button className="btn btn-sm btn-outline" style={{ flexShrink: 0 }} onClick={submitSticky}>Save Sticky</button>
+        <button style={{ padding: '6px 12px', borderRadius: 6, border: `1px solid ${JOURNAL_COLOR}`, background: 'transparent', color: JOURNAL_COLOR, fontSize: '0.85em', cursor: 'pointer', flexShrink: 0 }} onClick={submitSticky}>💾 Save</button>
         <div ref={menuRef} style={{ display: 'flex', position: 'relative', flexShrink: 0 }}>
-          <button className="btn btn-sm" style={{ background: JOURNAL_COLOR, color: '#000', borderTopRightRadius: 0, borderBottomRightRadius: 0 }} onClick={submitQuickCapture} title="Quick Capture (Ctrl+Q)">
+          <button style={{ padding: '6px 12px', borderRadius: 6, border: `1px solid ${JOURNAL_COLOR}`, background: 'transparent', color: JOURNAL_COLOR, fontSize: '0.85em', cursor: 'pointer', borderTopRightRadius: 0, borderBottomRightRadius: 0 }} onClick={submitQuickCapture} title="Quick Capture (Ctrl+Q)">
             {quickLabel}
           </button>
-          <button className="btn btn-sm" style={{ background: JOURNAL_COLOR, color: '#000', borderTopLeftRadius: 0, borderBottomLeftRadius: 0, borderLeft: '1px solid rgba(0,0,0,.2)', paddingInline: 8 }} onClick={() => setMenuOpen(o => !o)} aria-label="Quick capture options">
+          <button style={{ padding: '6px 8px', borderRadius: 6, border: `1px solid ${JOURNAL_COLOR}`, background: 'transparent', color: JOURNAL_COLOR, fontSize: '0.85em', cursor: 'pointer', borderTopLeftRadius: 0, borderBottomLeftRadius: 0 }} onClick={() => setMenuOpen(o => !o)} aria-label="Quick capture options">
             ▾
           </button>
           {menuOpen && (
@@ -109,6 +123,16 @@ function QuickCapture({ tags, onAddSticky, onOpenLongForm }) {
         </div>
         <span style={{ fontSize: '0.62em', color: 'var(--mut)', marginLeft: 'auto' }}>Ctrl+Q</span>
       </div>
+      {charCount > 900 && charCount <= 1000 && (
+        <div style={{ fontSize: '0.77em', color: 'var(--sp)', marginTop: 4 }}>
+          Approaching sticky size limit ({1000 - charCount} chars left). Past this, content will convert to a Journal entry.
+        </div>
+      )}
+      {charCount > 1000 && (
+        <div style={{ fontSize: '0.77em', color: JOURNAL_COLOR, marginTop: 4 }}>
+          📝 This will save as a Journal entry instead of a sticky.
+        </div>
+      )}
     </div>
   )
 }
@@ -515,18 +539,14 @@ function StickyBoard({
                         {sendOpenId === c.id && <SendToMenu sticky={c} onSend={(sticky, target) => { onSendTo(sticky, target); setSendOpenId(null) }} />}
                       </div>
                     )}
-                    <button onClick={() => onDelete(c.id)} title="Delete" style={{ fontSize: '0.62em', padding: '1px 6px', borderRadius: 4, border: '1px solid rgba(255,0,0,.3)', background: 'none', color: '#cc0000', cursor: 'pointer' }}>✕</button>
                   </div>
 
                   <div style={{ fontSize: '0.62em', marginTop: 6, color: textColor, opacity: 0.8 }}>
-                    {c.archived
-                      ? (
-                        <button onClick={() => c.archived_destination && c.archived_destination_id && crossLink?.(c.archived_destination, c.archived_destination_id)} style={{ border: 'none', background: 'none', color: textColor, cursor: c.archived_destination ? 'pointer' : 'default', padding: 0, fontSize: 'inherit' }}>
-                          📦 → {c.archived_destination ? c.archived_destination[0].toUpperCase() + c.archived_destination.slice(1) : 'Archived'}
-                        </button>
-                        )
-                      : <span>Send to → Choose destination</span>
-                    }
+                    {c.archived && (
+                      <button onClick={() => c.archived_destination && c.archived_destination_id && crossLink?.(c.archived_destination, c.archived_destination_id)} style={{ border: 'none', background: 'none', color: textColor, cursor: c.archived_destination ? 'pointer' : 'default', padding: 0, fontSize: 'inherit' }}>
+                        📦 → {c.archived_destination ? c.archived_destination[0].toUpperCase() + c.archived_destination.slice(1) : 'Archived'}
+                      </button>
+                    )}
                   </div>
 
                   {controlsOpen.has(c.id) && (
@@ -557,6 +577,7 @@ function StickyBoard({
                         <input type="checkbox" checked={!!c.pinned_journal} onChange={e => onEdit({ ...c, pinned_journal: e.target.checked })} />
                         📌 Also pin to Journal sidebar
                       </label>
+                      <button onClick={() => onDelete(c.id)} title="Delete" style={{ fontSize: '0.62em', padding: '1px 6px', borderRadius: 4, border: '1px solid rgba(255,0,0,.3)', background: 'none', color: '#cc0000', cursor: 'pointer' }}>✕ Delete</button>
                     </div>
                   )}
                 </>
@@ -569,7 +590,7 @@ function StickyBoard({
   )
 }
 
-export default function StickiesView({ db, pendingExpandId, clearPendingExpandId, crossLink }) {
+export default function StickiesView({ db, pendingExpandId, clearPendingExpandId, crossLink, goToSubTab }) {
   const [tags, setTags] = useState(() => lsGet('gcomp_journal_tags', DEFAULT_TAGS))
   const [captures, setCaptures] = useState(() => lsGet('gcomp_captures', []).map((c, i) => normalizeSticky(c, i)))
   const [showTagManager, setShowTagManager] = useState(false)
@@ -619,7 +640,20 @@ export default function StickiesView({ db, pendingExpandId, clearPendingExpandId
     db.upsertEntry('journal_captures', entry)
   }
 
-  function openLongForm(prefill = '') {
+  function openLongForm(prefill = '', fromOverflow = false) {
+    if (fromOverflow) {
+      db.upsertEntry('notes', {
+        id: uid(),
+        title: prefill.slice(0, 50),
+        content: prefill,
+        category: 'Brainstorm',
+        auto_imported: false,
+        source: 'sticky-overflow',
+        created: new Date().toISOString(),
+        updated: new Date().toISOString(),
+      })
+      return
+    }
     setLongFormDraft({ title: '', category: 'Brainstorm', content: prefill })
     setLongFormOpen(true)
   }
@@ -709,7 +743,10 @@ export default function StickiesView({ db, pendingExpandId, clearPendingExpandId
 
   const archivedCount = captures.filter(c => c.archived).length
   const isMobile = typeof window !== 'undefined' ? window.innerWidth < 700 : false
-  const recentCaptures = sortStickies(captures).slice(0, 8)
+  const recentCaptures = [...captures]
+    .sort((a, b) => new Date(b.created || 0) - new Date(a.created || 0))
+    .slice(0, 8)
+  const recentIdeas = [...ideas].sort((a, b) => new Date(b.created_at || 0) - new Date(a.created_at || 0))
 
   return (
     <div>
@@ -729,15 +766,20 @@ export default function StickiesView({ db, pendingExpandId, clearPendingExpandId
         {(!isMobile || mobileZone === 'capture') && (
           <div style={{ width: isMobile ? '100%' : 260, flexShrink: 0 }}>
             <QuickCapture tags={tags} onAddSticky={addCapture} onOpenLongForm={openLongForm} />
-            <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
-              <button onClick={() => setShowArchived(v => !v)} style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 999, border: `1px solid ${showArchived ? NOTES_COLOR : 'var(--brd)'}`, background: showArchived ? '#ffcc0022' : 'none', color: showArchived ? NOTES_COLOR : 'var(--dim)', cursor: 'pointer' }}>
-                👁 Show archived ({archivedCount})
-              </button>
-              <button onClick={() => setArchivedOnly(v => !v)} style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 999, border: `1px solid ${archivedOnly ? NOTES_COLOR : 'var(--brd)'}`, background: archivedOnly ? '#ffcc0022' : 'none', color: archivedOnly ? NOTES_COLOR : 'var(--dim)', cursor: 'pointer' }}>
-                Archived only
-              </button>
-            </div>
-            <IdeasPanel ideas={ideas} setIdeas={setIdeas} />
+            {recentIdeas.length > 0 && (
+              <div style={{ marginBottom: 12, padding: 8, background: 'var(--card)', borderRadius: 6, border: '1px solid var(--brd)' }}>
+                <div style={{ fontSize: '0.77em', color: 'var(--mut)', marginBottom: 6, display: 'flex', justifyContent: 'space-between' }}>
+                  <span>💡 Recent Ideas</span>
+                  <button onClick={() => goToSubTab?.('ideas')} style={{ fontSize: '0.77em', color: JOURNAL_COLOR, background: 'none', border: 'none', cursor: 'pointer' }}>see all →</button>
+                </div>
+                {recentIdeas.slice(0, 5).map(i => (
+                  <div key={i.id} style={{ padding: '5px 6px', marginBottom: 4, background: 'var(--sf)', borderRadius: 6, fontSize: '0.77em', color: 'var(--tx)' }}>
+                    <div>{i.value}</div>
+                    <div style={{ fontSize: '0.69em', color: 'var(--mut)', marginTop: 2 }}>{i.category}</div>
+                  </div>
+                ))}
+              </div>
+            )}
             <div style={{ fontSize: '0.77em', color: 'var(--mut)', marginBottom: 6 }}>Recent captures</div>
             {recentCaptures.map(c => {
               const sc = STICKY_COLORS.find(x => x.id === c.color) || STICKY_COLORS[0]
@@ -756,6 +798,14 @@ export default function StickiesView({ db, pendingExpandId, clearPendingExpandId
 
         {(!isMobile || mobileZone === 'stickies') && (
           <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
+              <button onClick={() => setShowArchived(v => !v)} style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 999, border: `1px solid ${showArchived ? NOTES_COLOR : 'var(--brd)'}`, background: showArchived ? `${NOTES_COLOR}22` : 'none', color: showArchived ? NOTES_COLOR : 'var(--dim)', cursor: 'pointer' }}>
+                👁 Show archived ({archivedCount})
+              </button>
+              <button onClick={() => setArchivedOnly(v => !v)} style={{ fontSize: '0.77em', padding: '4px 10px', borderRadius: 999, border: `1px solid ${archivedOnly ? NOTES_COLOR : 'var(--brd)'}`, background: archivedOnly ? `${NOTES_COLOR}22` : 'none', color: archivedOnly ? NOTES_COLOR : 'var(--dim)', cursor: 'pointer' }}>
+                Archived only
+              </button>
+            </div>
             <StickyBoard
               captures={captures}
               tags={tags}


### PR DESCRIPTION
## What changed
- adds the PR #13 polish follow-up on top of the existing session import, notes restructure, dashboard, and manuscript work
- fixes the character sort, world jump-bar hookup, crosslink timing, recent-capture ordering, archived journal pin filtering, and manuscript paragraph handling
- expands the notes parent tab with an Ideas sub-tab and continues the stickies/journal split work
- restores Inventory as the routed home for items/outfits, adds the significant-only filter, and keeps the unrouted files in place
- broadens dashboard search/review polish, activity log wiring, and cache-bump/build verification
- converts the requested inline pixel font sizes to `em` values in the specified tabs so the global A+/A− scaling propagates correctly

## Validation
- `npm.cmd run build`
- Vite production build completed successfully

## Note
PR #12 was already merged/closed before this push, so this PR carries the new follow-up polish commit (`a83fec7`) on the same feature branch.